### PR TITLE
Update updateConsents API

### DIFF
--- a/Sources/Public/Consent+PublicAPI.swift
+++ b/Sources/Public/Consent+PublicAPI.swift
@@ -38,8 +38,8 @@ import Foundation
 
     /// Merges the existing consents with the given consents. Duplicate keys will take the value of those passed in the API
     /// - Parameter consents: consents to be merged with the existing consents
-    @objc(updateConsents:)
-    static func update(consents: Consents) {
+    @objc(updateWithConsents:)
+    static func update(with consents: Consents) {
         let consentPrefs = ConsentPreferences(consents: consents)
         let event = Event(name: ConsentConstants.EventNames.CONSENT_UPDATE,
                           type: EventType.consent,

--- a/Tests/FunctionalTests/ConsentPublicAPITests.swift
+++ b/Tests/FunctionalTests/ConsentPublicAPITests.swift
@@ -52,7 +52,7 @@ class ConsentPublicAPITests: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
 
-    // MARK: updateConsents(...) test
+    // MARK: update(with consents:...) test
 
     /// Ensures that update consents API dispatches the correct event with correct event data
     func testUpdateConsents() {
@@ -69,7 +69,7 @@ class ConsentPublicAPITests: XCTestCase {
         }
 
         // test
-        Consent.update(consents: consents)
+        Consent.update(with: consents)
 
         // verify
         wait(for: [expectation], timeout: 1)


### PR DESCRIPTION
Instead of Consent.updateConsents(consents: ...) it is Consent.update(consents: ...)

thoughts?