### PR TITLE
Fix test-podspec script by removing pod versions

### DIFF
--- a/Script/test-podspec.sh
+++ b/Script/test-podspec.sh
@@ -28,10 +28,10 @@ echo "
 platform :ios, '10.0'
 target '$PROJECT_NAME' do
   use_frameworks!
-  pod 'AEPCore', '~> 3.0'
-  pod 'AEPServices', '~> 3.0'
-  pod 'AEPRulesEngine', '~> 1.0.0'
-  pod 'AEPEdge', '~> 1.0.0'
+  pod 'AEPCore'
+  pod 'AEPServices'
+  pod 'AEPRulesEngine'
+  pod 'AEPEdge'
   pod 'AEPEdgeConsent', :path => '../AEPEdgeConsent.podspec'
 end
 " >>Podfile


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The test-podspec script failed because the podfile optimistic version for AEPEdge was set to low and the current AEPEdge version could be loaded. Fix by removing the version specifications for the pods in the podfile.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
