### PR TITLE
Embed and Sign for AEPEdgeConsent.framework in Test apps and Update PodFile

### DIFF
--- a/AEPEdgeConsent.xcodeproj/project.pbxproj
+++ b/AEPEdgeConsent.xcodeproj/project.pbxproj
@@ -54,6 +54,12 @@
 		30124AD4C967CCE6E441C0AF /* Pods_FunctionalTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 79824FF2DC5D9EF797353B8F /* Pods_FunctionalTests.framework */; };
 		5E79E859C13FA3D7D09F8B67 /* Pods_AEPEdgeConsent.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4FBFA31E93600F3EFABBAAD5 /* Pods_AEPEdgeConsent.framework */; };
 		667E387BF7FBF6B6068678E7 /* Pods_TestApptvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09645E3D3E3CB9984BF5C6F7 /* Pods_TestApptvOS.framework */; };
+		9290E2C72BA5048500D2D393 /* AEPEdgeConsent.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2170713B25BB5BEA0052BACE /* AEPEdgeConsent.framework */; };
+		9290E2C82BA5048500D2D393 /* AEPEdgeConsent.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2170713B25BB5BEA0052BACE /* AEPEdgeConsent.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9290E2CC2BA5048900D2D393 /* AEPEdgeConsent.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2170713B25BB5BEA0052BACE /* AEPEdgeConsent.framework */; };
+		9290E2CD2BA5048900D2D393 /* AEPEdgeConsent.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2170713B25BB5BEA0052BACE /* AEPEdgeConsent.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9290E2D12BA5048D00D2D393 /* AEPEdgeConsent.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2170713B25BB5BEA0052BACE /* AEPEdgeConsent.framework */; };
+		9290E2D22BA5048D00D2D393 /* AEPEdgeConsent.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2170713B25BB5BEA0052BACE /* AEPEdgeConsent.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A44A5DA94D4EFCC852D2D2C4 /* Pods_TestApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF8D71F5046A8978899196E8 /* Pods_TestApp.framework */; };
 		B6F662302604B3C600BB6DD2 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = B6F6622F2604B3C600BB6DD2 /* AppDelegate.m */; };
 		B6F662362604B3C600BB6DD2 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B6F662352604B3C600BB6DD2 /* ViewController.m */; };
@@ -103,6 +109,27 @@
 			remoteGlobalIDString = 2170713A25BB5BEA0052BACE;
 			remoteInfo = AEPConsent;
 		};
+		9290E2C92BA5048500D2D393 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2170713225BB5BEA0052BACE /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2170713A25BB5BEA0052BACE;
+			remoteInfo = AEPEdgeConsent;
+		};
+		9290E2CE2BA5048900D2D393 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2170713225BB5BEA0052BACE /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2170713A25BB5BEA0052BACE;
+			remoteInfo = AEPEdgeConsent;
+		};
+		9290E2D32BA5048D00D2D393 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2170713225BB5BEA0052BACE /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2170713A25BB5BEA0052BACE;
+			remoteInfo = AEPEdgeConsent;
+		};
 		B6F662642604B86500BB6DD2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 2170713225BB5BEA0052BACE /* Project object */;
@@ -111,6 +138,42 @@
 			remoteInfo = AEPEdgeConsent;
 		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		9290E2CB2BA5048500D2D393 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				9290E2C82BA5048500D2D393 /* AEPEdgeConsent.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9290E2D02BA5048900D2D393 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				9290E2CD2BA5048900D2D393 /* AEPEdgeConsent.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9290E2D52BA5048D00D2D393 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				9290E2D22BA5048D00D2D393 /* AEPEdgeConsent.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		09645E3D3E3CB9984BF5C6F7 /* Pods_TestApptvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TestApptvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -208,6 +271,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A44A5DA94D4EFCC852D2D2C4 /* Pods_TestApp.framework in Frameworks */,
+				9290E2C72BA5048500D2D393 /* AEPEdgeConsent.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -216,6 +280,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				667E387BF7FBF6B6068678E7 /* Pods_TestApptvOS.framework in Frameworks */,
+				9290E2D12BA5048D00D2D393 /* AEPEdgeConsent.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -224,6 +289,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B7F76628958B331CDE628174 /* Pods_TestAppObjC.framework in Frameworks */,
+				9290E2CC2BA5048900D2D393 /* AEPEdgeConsent.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -482,11 +548,13 @@
 				21D4BAA625E9724E00DD11AF /* Resources */,
 				82BD9E88973E1020BD15067F /* [CP] Embed Pods Frameworks */,
 				2E18855F29A6B70600A994E8 /* ShellScript */,
+				9290E2CB2BA5048500D2D393 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				21D4BADE25E9766B00DD11AF /* PBXTargetDependency */,
+				9290E2CA2BA5048500D2D393 /* PBXTargetDependency */,
 			);
 			name = TestApp;
 			productName = AEPConsentTestApp;
@@ -503,11 +571,13 @@
 				2EDF618D287CC84D007DCFCC /* Resources */,
 				2B8D3072437203E0B80A73F8 /* [CP] Embed Pods Frameworks */,
 				2E18856029A6B70D00A994E8 /* ShellScript */,
+				9290E2D52BA5048D00D2D393 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				2EDF6184287CC84D007DCFCC /* PBXTargetDependency */,
+				9290E2D42BA5048D00D2D393 /* PBXTargetDependency */,
 			);
 			name = TestApptvOS;
 			productName = AEPConsentTestApp;
@@ -523,11 +593,13 @@
 				B6F662292604B3C600BB6DD2 /* Frameworks */,
 				B6F6622A2604B3C600BB6DD2 /* Resources */,
 				5E9E9A664859CDC1ED329CAC /* [CP] Embed Pods Frameworks */,
+				9290E2D02BA5048900D2D393 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				B6F662652604B86500BB6DD2 /* PBXTargetDependency */,
+				9290E2CF2BA5048900D2D393 /* PBXTargetDependency */,
 			);
 			name = TestAppObjC;
 			productName = TestAppObjc;
@@ -1049,6 +1121,21 @@
 			target = 2170713A25BB5BEA0052BACE /* AEPEdgeConsent */;
 			targetProxy = 2EDF6185287CC84D007DCFCC /* PBXContainerItemProxy */;
 		};
+		9290E2CA2BA5048500D2D393 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2170713A25BB5BEA0052BACE /* AEPEdgeConsent */;
+			targetProxy = 9290E2C92BA5048500D2D393 /* PBXContainerItemProxy */;
+		};
+		9290E2CF2BA5048900D2D393 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2170713A25BB5BEA0052BACE /* AEPEdgeConsent */;
+			targetProxy = 9290E2CE2BA5048900D2D393 /* PBXContainerItemProxy */;
+		};
+		9290E2D42BA5048D00D2D393 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2170713A25BB5BEA0052BACE /* AEPEdgeConsent */;
+			targetProxy = 9290E2D32BA5048D00D2D393 /* PBXContainerItemProxy */;
+		};
 		B6F662652604B86500BB6DD2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 2170713A25BB5BEA0052BACE /* AEPEdgeConsent */;
@@ -1395,6 +1482,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"TestApp/Preview Content\"";
+				DEVELOPMENT_TEAM = FKGEE875K4;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = TestApp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -1418,6 +1506,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"TestApp/Preview Content\"";
+				DEVELOPMENT_TEAM = FKGEE875K4;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = TestApp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;

--- a/Podfile
+++ b/Podfile
@@ -10,41 +10,41 @@ project 'AEPEdgeConsent.xcodeproj'
 pod 'SwiftLint', '0.52.0'
 
 target 'AEPEdgeConsent' do
-  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v5.0.0'
-  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v5.0.0'
-  pod 'AEPRulesEngine', :git => 'https://github.com/adobe/aepsdk-rulesengine-ios.git', :branch => 'dev-v5.0.0'
+  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'staging'
+  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'staging'
+  pod 'AEPRulesEngine', :git => 'https://github.com/adobe/aepsdk-rulesengine-ios.git', :branch => 'staging'
 end
 
 target 'UnitTests' do
-  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v5.0.0'
-  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v5.0.0'
-  pod 'AEPRulesEngine', :git => 'https://github.com/adobe/aepsdk-rulesengine-ios.git', :branch => 'dev-v5.0.0'
+  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'staging'
+  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'staging'
+  pod 'AEPRulesEngine', :git => 'https://github.com/adobe/aepsdk-rulesengine-ios.git', :branch => 'staging'
   pod 'AEPTestUtils', :git => 'https://github.com/adobe/aepsdk-testutils-ios.git', :branch => 'feature/latest'
 end
 
 target 'FunctionalTests' do
-  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v5.0.0'
-  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v5.0.0'
-  pod 'AEPRulesEngine', :git => 'https://github.com/adobe/aepsdk-rulesengine-ios.git', :branch => 'dev-v5.0.0'
+  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'staging'
+  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'staging'
+  pod 'AEPRulesEngine', :git => 'https://github.com/adobe/aepsdk-rulesengine-ios.git', :branch => 'staging'
   pod 'AEPTestUtils', :git => 'https://github.com/adobe/aepsdk-testutils-ios.git', :branch => 'feature/latest'
 end
 
 target 'TestApp' do
-  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v5.0.0'
-  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v5.0.0'
-  pod 'AEPRulesEngine', :git => 'https://github.com/adobe/aepsdk-rulesengine-ios.git', :branch => 'dev-v5.0.0'
+  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'staging'
+  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'staging'
+  pod 'AEPRulesEngine', :git => 'https://github.com/adobe/aepsdk-rulesengine-ios.git', :branch => 'staging'
 end
 
 target 'TestApptvOS' do
-  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v5.0.0'
-  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v5.0.0'
-  pod 'AEPRulesEngine', :git => 'https://github.com/adobe/aepsdk-rulesengine-ios.git', :branch => 'dev-v5.0.0'
+  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'staging'
+  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'staging'
+  pod 'AEPRulesEngine', :git => 'https://github.com/adobe/aepsdk-rulesengine-ios.git', :branch => 'staging'
 end
 
 target 'TestAppObjC' do
-  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v5.0.0'
-  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v5.0.0'
-  pod 'AEPRulesEngine', :git => 'https://github.com/adobe/aepsdk-rulesengine-ios.git', :branch => 'dev-v5.0.0'
+  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'staging'
+  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'staging'
+  pod 'AEPRulesEngine', :git => 'https://github.com/adobe/aepsdk-rulesengine-ios.git', :branch => 'staging'
 end
 
 post_install do |pi|

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -10,9 +10,9 @@ PODS:
   - SwiftLint (0.52.0)
 
 DEPENDENCIES:
-  - AEPCore (from `https://github.com/adobe/aepsdk-core-ios.git`, branch `dev-v5.0.0`)
-  - AEPRulesEngine (from `https://github.com/adobe/aepsdk-rulesengine-ios.git`, branch `dev-v5.0.0`)
-  - AEPServices (from `https://github.com/adobe/aepsdk-core-ios.git`, branch `dev-v5.0.0`)
+  - AEPCore (from `https://github.com/adobe/aepsdk-core-ios.git`, branch `staging`)
+  - AEPRulesEngine (from `https://github.com/adobe/aepsdk-rulesengine-ios.git`, branch `staging`)
+  - AEPServices (from `https://github.com/adobe/aepsdk-core-ios.git`, branch `staging`)
   - AEPTestUtils (from `https://github.com/adobe/aepsdk-testutils-ios.git`, branch `feature/latest`)
   - SwiftLint (= 0.52.0)
 
@@ -22,13 +22,13 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   AEPCore:
-    :branch: dev-v5.0.0
+    :branch: staging
     :git: https://github.com/adobe/aepsdk-core-ios.git
   AEPRulesEngine:
-    :branch: dev-v5.0.0
+    :branch: staging
     :git: https://github.com/adobe/aepsdk-rulesengine-ios.git
   AEPServices:
-    :branch: dev-v5.0.0
+    :branch: staging
     :git: https://github.com/adobe/aepsdk-core-ios.git
   AEPTestUtils:
     :branch: feature/latest
@@ -36,13 +36,13 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   AEPCore:
-    :commit: ff1f00c9895be50f87414a2085ef234edd63081b
+    :commit: f44b7b0d66e2c6a1454b51ed5a9d835bfbc2a8f9
     :git: https://github.com/adobe/aepsdk-core-ios.git
   AEPRulesEngine:
-    :commit: 01bd861e9df32b4d2dc784b2b94d87835e813c53
+    :commit: 7750ad5041c23c76053713441546116738e0fdcb
     :git: https://github.com/adobe/aepsdk-rulesengine-ios.git
   AEPServices:
-    :commit: ff1f00c9895be50f87414a2085ef234edd63081b
+    :commit: f44b7b0d66e2c6a1454b51ed5a9d835bfbc2a8f9
     :git: https://github.com/adobe/aepsdk-core-ios.git
   AEPTestUtils:
     :commit: 88b9887c6b504fe39139b736a6360e9e2746496b
@@ -55,6 +55,6 @@ SPEC CHECKSUMS:
   AEPTestUtils: 756e5997318be74584057d7628941c737d358640
   SwiftLint: 13280e21cdda6786ad908dc6e416afe5acd1fcb7
 
-PODFILE CHECKSUM: b7e388e6b6ec2b850c6730cad9a38c2f051c40fc
+PODFILE CHECKSUM: aed68707c71d080b3a4fc815fe312af5591be77a
 
 COCOAPODS: 1.14.3


### PR DESCRIPTION
Embed and Sign for AEPEdgeConsent.framework in Test apps, so it can be run on the devices. PodFile update to core staging branch

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
