### PR TITLE
Only dispatch consent preferences on change, if configuration set to do so.

### DIFF
--- a/Sources/Consent.swift
+++ b/Sources/Consent.swift
@@ -79,12 +79,15 @@ public class Consent: NSObject, Extension {
             return
         }
 
-        // set metadata
-        newPreferences.setTimestamp(date: event.timestamp)
-        preferencesManager.mergeAndUpdate(with: newPreferences)
-        shareCurrentConsents(event: event)
-        // Share only changed preferences instead of all preferences to prevent accidental sharing of default consents.
-        dispatchEdgeConsentUpdateEvent(preferences: newPreferences)
+        // Only proceed with Edge event dispatch if preferences actually changed
+        if preferencesManager.mergeAndUpdate(with: newPreferences) {
+            // Add timestamp after checking for change in preferences to prevent false positive from timestamp differences.
+            newPreferences.setTimestamp(date: event.timestamp)
+            preferencesManager.mergeAndUpdate(with: newPreferences) // re-apply with updated metadata
+
+            shareCurrentConsents(event: event)
+            dispatchEdgeConsentUpdateEvent(preferences: newPreferences)
+        }
     }
 
     /// Invoked when an event with `EventType.edge` and source `consent:preferences` is dispatched

--- a/Sources/Consent.swift
+++ b/Sources/Consent.swift
@@ -24,6 +24,8 @@ public class Consent: NSObject, Extension {
 
     private var preferencesManager = ConsentPreferencesManager()
 
+    private var forceSync = ConsentConstants.Defaults.CONSENT_FORCE_SYNC
+
     // MARK: Extension
 
     public required init?(runtime: ExtensionRuntime) {
@@ -80,7 +82,7 @@ public class Consent: NSObject, Extension {
         }
 
         // Only proceed with Edge event dispatch if preferences actually changed
-        if preferencesManager.mergeAndUpdate(with: newPreferences) {
+        if preferencesManager.mergeAndUpdate(with: newPreferences) || forceSync {
             // Add timestamp after checking for change in preferences to prevent false positive from timestamp differences.
             newPreferences.setTimestamp(date: event.timestamp)
             preferencesManager.mergeAndUpdate(with: newPreferences) // re-apply with updated metadata
@@ -165,6 +167,10 @@ public class Consent: NSObject, Extension {
 
         if preferencesManager.updateDefaults(with: defaultPrefs) {
             shareCurrentConsents(event: event)
+        }
+
+        if let forceSync = config[ConsentConstants.SharedState.Configuration.CONSENT_FORCE_SYNC] as? Bool {
+            self.forceSync = forceSync
         }
     }
 }

--- a/Sources/Consent.swift
+++ b/Sources/Consent.swift
@@ -24,7 +24,12 @@ public class Consent: NSObject, Extension {
 
     private var preferencesManager = ConsentPreferencesManager()
 
+    // The forceSync flag, false means the SDK will only sync if preferences have changed.
+    // Flag updated via configuration shared state.
     private var forceSync = ConsentConstants.Defaults.CONSENT_FORCE_SYNC
+
+    // The last time a consent update was processed from public API.
+    private var lastConsentUpdateTime: Date?
 
     // MARK: Extension
 
@@ -82,13 +87,15 @@ public class Consent: NSObject, Extension {
         }
 
         // Only proceed with Edge event dispatch if preferences actually changed
-        if preferencesManager.mergeAndUpdate(with: newPreferences) || forceSync {
+        if preferencesManager.mergeAndUpdate(with: newPreferences) || shouldForceSync(event: event) {
             // Add timestamp after checking for change in preferences to prevent false positive from timestamp differences.
             newPreferences.setTimestamp(date: event.timestamp)
             preferencesManager.mergeAndUpdate(with: newPreferences) // re-apply with updated metadata
 
             shareCurrentConsents(event: event)
             dispatchEdgeConsentUpdateEvent(preferences: newPreferences)
+
+            lastConsentUpdateTime = event.timestamp
         }
     }
 
@@ -172,5 +179,20 @@ public class Consent: NSObject, Extension {
         if let forceSync = config[ConsentConstants.SharedState.Configuration.CONSENT_FORCE_SYNC] as? Bool {
             self.forceSync = forceSync
         }
+    }
+
+    /// Returns true if the SDK should force a sync of consents.
+    /// Checks if forceSync is true and if the last consent update was too recent.
+    /// - Parameter event: the event that triggered the sync.
+    private func shouldForceSync(event: Event) -> Bool {
+        if !forceSync {
+            return false
+        }
+
+        guard let lastConsentUpdateTime = lastConsentUpdateTime else {
+            return true
+        }
+
+        return event.timestamp.timeIntervalSince(lastConsentUpdateTime) > ConsentConstants.Defaults.IGNORE_CONSENT_UPDATES_INTERVAL
     }
 }

--- a/Sources/ConsentConstants.swift
+++ b/Sources/ConsentConstants.swift
@@ -21,6 +21,8 @@ enum ConsentConstants {
     enum Defaults {
         // Default value for the forceSync flag, false means the SDK will only sync if preferences have changed.
         static let CONSENT_FORCE_SYNC = false
+        // The interval to ignore consecutive consent updates, in seconds.
+        static let IGNORE_CONSENT_UPDATES_INTERVAL: TimeInterval = 1
     }
 
     enum EventDataKeys {

--- a/Sources/ConsentConstants.swift
+++ b/Sources/ConsentConstants.swift
@@ -18,6 +18,11 @@ enum ConsentConstants {
     static let EXTENSION_VERSION = "5.0.0"
     static let LOG_TAG = FRIENDLY_NAME
 
+    enum Defaults {
+        // Default value for the forceSync flag, false means the SDK will only sync if preferences have changed.
+        static let CONSENT_FORCE_SYNC = false
+    }
+
     enum EventDataKeys {
         static let CONSENTS = "consents"
         static let METADATA = "metadata"
@@ -47,6 +52,7 @@ enum ConsentConstants {
         enum Configuration {
             static let STATE_OWNER_NAME = "com.adobe.module.configuration"
             static let CONSENT_DEFAULT = "consent.default"
+            static let CONSENT_FORCE_SYNC = "consent.forceSync"
         }
     }
 }

--- a/Tests/FunctionalTests/ConsentFunctionalTests.swift
+++ b/Tests/FunctionalTests/ConsentFunctionalTests.swift
@@ -652,6 +652,37 @@ class ConsentFunctionalTests: XCTestCase, AnyCodableAsserts {
         XCTAssertEqual(2, mockRuntime.dispatchedEvents.count) // consent response content + edge updateConsent
     }
 
+    func testUpdateConsentDispatchesEdgeEventAlwaysWhenForceSyncIsTrue() {
+        // Setup Configuration with forceSync set to true
+        let configUpdateEvent = Event(name: "Config update",
+                                      type: EventType.configuration,
+                                      source: EventSource.responseContent,
+                                      data: [ConsentConstants.SharedState.Configuration.CONSENT_FORCE_SYNC: true])
+        mockRuntime.simulateComingEvents(configUpdateEvent)
+
+        // Setup - initial consent update
+        let firstEvent = buildFirstUpdateConsentEvent()
+        mockRuntime.simulateComingEvents(firstEvent)
+        mockRuntime.resetDispatchedEventAndCreatedSharedStates()
+
+        // Test - same consent values
+        mockRuntime.simulateComingEvents(firstEvent)
+
+        // Verify - events dispatched for unchanged consents
+        XCTAssertEqual(1, mockRuntime.createdXdmSharedStates.count)
+        XCTAssertEqual(2, mockRuntime.dispatchedEvents.count)
+
+        mockRuntime.resetDispatchedEventAndCreatedSharedStates()
+
+        // Test - different consent values
+        let secondEvent = buildSecondUpdateConsentEvent()
+        mockRuntime.simulateComingEvents(secondEvent)
+
+        // Verify - events dispatched for changed consents
+        XCTAssertEqual(1, mockRuntime.createdXdmSharedStates.count)
+        XCTAssertEqual(2, mockRuntime.dispatchedEvents.count) // consent response content + edge updateConsent
+    }
+
     // MARK: Consent response event handling (consent:preferences)
 
     func testEmptyResponseNilPayload() {

--- a/Tests/FunctionalTests/ConsentFunctionalTests.swift
+++ b/Tests/FunctionalTests/ConsentFunctionalTests.swift
@@ -652,13 +652,9 @@ class ConsentFunctionalTests: XCTestCase, AnyCodableAsserts {
         XCTAssertEqual(2, mockRuntime.dispatchedEvents.count) // consent response content + edge updateConsent
     }
 
-    func testUpdateConsentDispatchesEdgeEventAlwaysWhenForceSyncIsTrue() {
+    func testUpdateConsentDoesNotDispatchEdgeEventWhenForceSyncIsTrueAndSameUpdateLessThanTimeout() {
         // Setup Configuration with forceSync set to true
-        let configUpdateEvent = Event(name: "Config update",
-                                      type: EventType.configuration,
-                                      source: EventSource.responseContent,
-                                      data: [ConsentConstants.SharedState.Configuration.CONSENT_FORCE_SYNC: true])
-        mockRuntime.simulateComingEvents(configUpdateEvent)
+        mockRuntime.simulateComingEvents(buildConfigUpdateForceSynceEvent(forceSync: true))
 
         // Setup - initial consent update
         let firstEvent = buildFirstUpdateConsentEvent()
@@ -667,6 +663,35 @@ class ConsentFunctionalTests: XCTestCase, AnyCodableAsserts {
 
         // Test - same consent values
         mockRuntime.simulateComingEvents(firstEvent)
+
+        // Verify - no events dispatched for unchanged consents as event timestamps are equal.
+        XCTAssertEqual(0, mockRuntime.createdXdmSharedStates.count)
+        XCTAssertEqual(0, mockRuntime.dispatchedEvents.count)
+
+        // Test - different consent values
+        let secondEvent = buildSecondUpdateConsentEvent()
+        mockRuntime.simulateComingEvents(secondEvent)
+
+        // Verify - events dispatched for changed consents
+        XCTAssertEqual(1, mockRuntime.createdXdmSharedStates.count)
+        XCTAssertEqual(2, mockRuntime.dispatchedEvents.count) // consent response content + edge updateConsent
+    }
+
+    func testUpdateConsentDispatchesEdgeEventWhenForceSyncIsTrueAndSameUpdateAfterTimeout() {
+        // Setup Configuration with forceSync set to true
+        mockRuntime.simulateComingEvents(buildConfigUpdateForceSynceEvent(forceSync: true))
+
+        // Setup - initial consent update
+        let firstEvent = buildFirstUpdateConsentEvent()
+        mockRuntime.simulateComingEvents(firstEvent)
+        mockRuntime.resetDispatchedEventAndCreatedSharedStates()
+
+        // Need to pause to add 1 second delta to event timestamps
+        Thread.sleep(forTimeInterval: ConsentConstants.Defaults.IGNORE_CONSENT_UPDATES_INTERVAL)
+
+        // Test - same consent values
+        let firstRepeatEvent = buildFirstUpdateConsentEvent()
+        mockRuntime.simulateComingEvents(firstRepeatEvent)
 
         // Verify - events dispatched for unchanged consents
         XCTAssertEqual(1, mockRuntime.createdXdmSharedStates.count)
@@ -1249,5 +1274,12 @@ class ConsentFunctionalTests: XCTestCase, AnyCodableAsserts {
         let config = [ConsentConstants.SharedState.Configuration.CONSENT_DEFAULT: cachedPrefs.asDictionary()]
 
         return Event(name: "Config update", type: EventType.configuration, source: EventSource.responseContent, data: config as [String: Any])
+    }
+
+    private func buildConfigUpdateForceSynceEvent(forceSync: Bool) -> Event {
+        return  Event(name: "Config update",
+                      type: EventType.configuration,
+                      source: EventSource.responseContent,
+                      data: [ConsentConstants.SharedState.Configuration.CONSENT_FORCE_SYNC: forceSync])
     }
 }

--- a/Tests/FunctionalTests/ConsentFunctionalTests.swift
+++ b/Tests/FunctionalTests/ConsentFunctionalTests.swift
@@ -629,6 +629,29 @@ class ConsentFunctionalTests: XCTestCase, AnyCodableAsserts {
             pathOptions: KeyMustBeAbsent(paths: "consents.adID.val"), CollectionEqualCount(scope: .subtree))
     }
 
+    func testUpdateConsentOnlyDispatchesEdgeEventOnChange() {
+        // Setup - initial consent update
+        let firstEvent = buildFirstUpdateConsentEvent()
+        mockRuntime.simulateComingEvents(firstEvent)
+        mockRuntime.resetDispatchedEventAndCreatedSharedStates()
+
+        // Test - same consent values
+        let firstRepeatEvent = buildFirstUpdateConsentEvent() // rebuild first event so timestamps are different
+        mockRuntime.simulateComingEvents(firstRepeatEvent)
+
+        // Verify - no events dispatched for unchanged consents
+        XCTAssertEqual(0, mockRuntime.createdXdmSharedStates.count)
+        XCTAssertEqual(0, mockRuntime.dispatchedEvents.count)
+
+        // Test - different consent values
+        let secondEvent = buildSecondUpdateConsentEvent()
+        mockRuntime.simulateComingEvents(secondEvent)
+
+        // Verify - events dispatched for changed consents
+        XCTAssertEqual(1, mockRuntime.createdXdmSharedStates.count)
+        XCTAssertEqual(2, mockRuntime.dispatchedEvents.count) // consent response content + edge updateConsent
+    }
+
     // MARK: Consent response event handling (consent:preferences)
 
     func testEmptyResponseNilPayload() {

--- a/Tests/UnitTests/ConsentPreferencesTests.swift
+++ b/Tests/UnitTests/ConsentPreferencesTests.swift
@@ -417,6 +417,77 @@ class ConsentPreferencesTests: XCTestCase, AnyCodableAsserts {
         XCTAssertTrue(equal)
     }
 
+    func testEqualsWithEqualConsentPreferences() {
+        // Setup
+        let consents = [
+            "adID": ["val": "y"],
+            "collect": ["val": "n"],
+            "metadata": ["time": Date().iso8601UTCWithMillisecondsString]
+        ]
+        let preferences1 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents)!)
+        let preferences2 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents)!)
+
+        // Test
+        XCTAssertTrue(preferences1 == preferences2)
+    }
+
+    func testEqualsWithDifferentConsentPreferences() {
+        // Setup
+        let consents1 = [
+            "adID": ["val": "y"],
+            "collect": ["val": "n"]
+        ]
+        let preferences1 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents1)!)
+        let consents2 = [
+            "adID": ["val": "y"],
+            "collect": ["val": "y"]
+        ]
+        let preferences2 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents2)!)
+
+        // Test
+        XCTAssertFalse(preferences1 == preferences2)
+    }
+
+    func testEqualsWithDifferentDictionaryOrder() {
+        // Setup
+        let timestamp = Date().iso8601UTCWithMillisecondsString
+        let consents1 = [
+            "adID": ["val": "y"],
+            "collect": ["val": "n"],
+            "metadata": ["time": timestamp]
+        ]
+        let consents2 = [
+            "collect": ["val": "n"],
+            "adID": ["val": "y"],
+            "metadata": ["time": timestamp]
+        ]
+        let preferences1 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents1)!)
+        let preferences2 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents2)!)
+
+        // Test
+        XCTAssertTrue(preferences1 == preferences2)
+    }
+
+    func testEqualsDifferentTimestamp() {
+        // Setup
+        let consents1 = [
+            "adID": ["val": "y"],
+            "collect": ["val": "n"],
+            "metadata": ["time": Date().iso8601UTCWithMillisecondsString]
+        ]
+        let consents2 = [
+            "adID": ["val": "y"],
+            "collect": ["val": "n"],
+            "metadata": ["time": Date().addingTimeInterval(10).iso8601UTCWithMillisecondsString]
+        ]
+        let preferences1 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents1)!)
+        let preferences2 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents2)!)
+
+        // Test
+        // Expect false because equality checks all values, including timestamp
+        XCTAssertFalse(preferences1 == preferences2)
+    }
+
     // MARK: from(config) tests
 
     func testFromEmptyConfig() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Optimizes Consent to only dispatch consent preference Edge events when the values change. This will reduce the number of network requests made when the preferences do not change. 

1. Adds a new boolean configuration flag `consent.forceSync` which if `false` (default) will only dispatch an Edge request event if the consent preferences change. If `true`, preserves the current behavior and dispatches an Edge request on each Consent update request.
2. Adds a sanity check to the current behavior (i.e. consent.forceSync = true) where if two Consent update requests with duplicate values are sent within a second of each other, the Edge request is not sent. This optimizes application implementation which may incorrectly make the same API call several times within a second.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
