### PR TITLE
Optimize consent update requests by ignoring duplicate requests which arrive within 1 second

### DIFF
--- a/Sources/Consent.swift
+++ b/Sources/Consent.swift
@@ -24,6 +24,9 @@ public class Consent: NSObject, Extension {
 
     private var preferencesManager = ConsentPreferencesManager()
 
+    // The last time a consent update was processed from public API. Initialize to date in the past.
+    private var lastConsentUpdateTime: Date = Date().addingTimeInterval(-(ConsentConstants.Defaults.IGNORE_CONSENT_UPDATES_INTERVAL * 2))
+
     // MARK: Extension
 
     public required init?(runtime: ExtensionRuntime) {
@@ -81,10 +84,22 @@ public class Consent: NSObject, Extension {
 
         // set metadata
         newPreferences.setTimestamp(date: event.timestamp)
-        preferencesManager.mergeAndUpdate(with: newPreferences)
-        shareCurrentConsents(event: event)
-        // Share only changed preferences instead of all preferences to prevent accidental sharing of default consents.
-        dispatchEdgeConsentUpdateEvent(preferences: newPreferences)
+        let outsideTimeout = event.timestamp.timeIntervalSince(lastConsentUpdateTime) > ConsentConstants.Defaults.IGNORE_CONSENT_UPDATES_INTERVAL
+
+        if preferencesManager.mergeAndUpdate(with: newPreferences) || outsideTimeout {
+            shareCurrentConsents(event: event)
+            // Share only changed preferences instead of all preferences to prevent accidental sharing of default consents.
+            dispatchEdgeConsentUpdateEvent(preferences: newPreferences)
+            lastConsentUpdateTime = event.timestamp
+        } else {
+            // If the consent preferences have not changed and arrived too soon after the previous synced preferences, ignore event.
+            let msg = """
+            Consent - Update request did not change preferences and is within \
+            \(ConsentConstants.Defaults.IGNORE_CONSENT_UPDATES_INTERVAL) \
+            sec of the previous request, dropping event.
+            """
+            Log.debug(label: ConsentConstants.LOG_TAG, msg)
+        }
     }
 
     /// Invoked when an event with `EventType.edge` and source `consent:preferences` is dispatched
@@ -102,13 +117,13 @@ public class Consent: NSObject, Extension {
             return
         }
 
-        if preferencesManager.mergeAndUpdate(with: newPreferences) {
-            if newPreferences.consents[ConsentConstants.EventDataKeys.METADATA] == nil {
-                // preferences were updated without providing metadata, update the metadata
-                newPreferences.setTimestamp(date: event.timestamp)
-                preferencesManager.mergeAndUpdate(with: newPreferences) // re-apply with updated metadata
-            }
+        // Set timestamp if needed
+        if newPreferences.consents[ConsentConstants.EventDataKeys.METADATA] == nil {
+            newPreferences.setTimestamp(date: event.timestamp)
+        }
 
+        // Merge and share preferences if changed
+        if preferencesManager.mergeAndUpdate(with: newPreferences) {
             shareCurrentConsents(event: event)
         }
     }

--- a/Sources/ConsentConstants.swift
+++ b/Sources/ConsentConstants.swift
@@ -19,7 +19,7 @@ enum ConsentConstants {
     static let LOG_TAG = FRIENDLY_NAME
 
     enum Defaults {
-        // The interval to ignore consecutive consent updates, in seconds.
+        /// The interval to ignore consecutive consent updates, in seconds.
         static let IGNORE_CONSENT_UPDATES_INTERVAL: TimeInterval = 1
     }
 

--- a/Sources/ConsentConstants.swift
+++ b/Sources/ConsentConstants.swift
@@ -18,6 +18,11 @@ enum ConsentConstants {
     static let EXTENSION_VERSION = "5.0.0"
     static let LOG_TAG = FRIENDLY_NAME
 
+    enum Defaults {
+        // The interval to ignore consecutive consent updates, in seconds.
+        static let IGNORE_CONSENT_UPDATES_INTERVAL: TimeInterval = 1
+    }
+
     enum EventDataKeys {
         static let CONSENTS = "consents"
         static let METADATA = "metadata"

--- a/Sources/ConsentPreferences.swift
+++ b/Sources/ConsentPreferences.swift
@@ -75,13 +75,30 @@ struct ConsentPreferences: Codable, Equatable {
         return defaultPrefs
     }
 
-    /// Determines if two `ConsentPreferences` are equal
+    /// Determines if two `ConsentPreferences` are equal.
+    /// Ignores the "consents.metadata.time" field.
     /// - Parameters:
     ///   - lhs: a `ConsentPreferences`
     ///   - rhs: a `ConsentPreferences`
     /// - Returns: true if they are equal, otherwise false
     static func == (lhs: ConsentPreferences, rhs: ConsentPreferences) -> Bool {
-        return NSDictionary(dictionary: lhs.asDictionary() ?? [:]).isEqual(to: rhs.asDictionary() ?? [:])
+        var lhsDict = lhs.asDictionary() ?? [:]
+        if var lhsConsents = lhsDict[ConsentConstants.EventDataKeys.CONSENTS] as? [String: Any],
+           var lhsMetaData = lhsConsents[ConsentConstants.EventDataKeys.METADATA] as? [String: Any] {
+            lhsMetaData.removeValue(forKey: ConsentConstants.EventDataKeys.TIME)
+            lhsConsents[ConsentConstants.EventDataKeys.METADATA] = lhsMetaData
+            lhsDict[ConsentConstants.EventDataKeys.CONSENTS] = lhsConsents
+        }
+
+        var rhsDict = rhs.asDictionary() ?? [:]
+        if var rhsConsents = rhsDict[ConsentConstants.EventDataKeys.CONSENTS] as? [String: Any],
+           var rhsMetaData = rhsConsents[ConsentConstants.EventDataKeys.METADATA] as? [String: Any] {
+            rhsMetaData.removeValue(forKey: ConsentConstants.EventDataKeys.TIME)
+            rhsConsents[ConsentConstants.EventDataKeys.METADATA] = rhsMetaData
+            rhsDict[ConsentConstants.EventDataKeys.CONSENTS] = rhsConsents
+        }
+
+        return NSDictionary(dictionary: lhsDict).isEqual(to: rhsDict)
     }
 
 }

--- a/Tests/FunctionalTests/ConsentFunctionalTests.swift
+++ b/Tests/FunctionalTests/ConsentFunctionalTests.swift
@@ -651,6 +651,21 @@ class ConsentFunctionalTests: XCTestCase, AnyCodableAsserts {
         XCTAssertEqual(2, mockRuntime.dispatchedEvents.count) // consent response content + edge updateConsent
     }
 
+    func testUpdateConsentDispatchesEdgeEventWhenDifferentUpdateLessThanTimeout() {
+        // Setup - initial consent update
+        let firstEvent = buildFirstUpdateConsentEvent()
+        mockRuntime.simulateComingEvents(firstEvent)
+        mockRuntime.resetDispatchedEventAndCreatedSharedStates()
+
+        // Test - different consent values
+        let secondEvent = buildSecondUpdateConsentEvent()
+        mockRuntime.simulateComingEvents(secondEvent)
+
+        // Verify - events dispatched for changed consents withing timeout
+        XCTAssertEqual(1, mockRuntime.createdXdmSharedStates.count)
+        XCTAssertEqual(2, mockRuntime.dispatchedEvents.count)
+    }
+
     func testUpdateConsentDispatchesEdgeEventWhenSameUpdateAfterTimeout() {
         // Setup - initial consent update
         let firstEvent = buildFirstUpdateConsentEvent()

--- a/Tests/FunctionalTests/ConsentFunctionalTests.swift
+++ b/Tests/FunctionalTests/ConsentFunctionalTests.swift
@@ -661,7 +661,7 @@ class ConsentFunctionalTests: XCTestCase, AnyCodableAsserts {
         let secondEvent = buildSecondUpdateConsentEvent()
         mockRuntime.simulateComingEvents(secondEvent)
 
-        // Verify - events dispatched for changed consents withing timeout
+        // Verify - events dispatched for changed consents within timeout
         XCTAssertEqual(1, mockRuntime.createdXdmSharedStates.count)
         XCTAssertEqual(2, mockRuntime.dispatchedEvents.count)
     }

--- a/Tests/FunctionalTests/ConsentFunctionalTests.swift
+++ b/Tests/FunctionalTests/ConsentFunctionalTests.swift
@@ -629,6 +629,56 @@ class ConsentFunctionalTests: XCTestCase, AnyCodableAsserts {
             pathOptions: KeyMustBeAbsent(paths: "consents.adID.val"), CollectionEqualCount(scope: .subtree))
     }
 
+    func testUpdateConsentDoesNotDispatchEdgeEventWhenSameUpdateLessThanTimeout() {
+        // Setup - initial consent update
+        let firstEvent = buildFirstUpdateConsentEvent()
+        mockRuntime.simulateComingEvents(firstEvent)
+        mockRuntime.resetDispatchedEventAndCreatedSharedStates()
+
+        // Test - same consent values
+        mockRuntime.simulateComingEvents(firstEvent)
+
+        // Verify - no events dispatched for unchanged consents as event timestamps are equal.
+        XCTAssertEqual(0, mockRuntime.createdXdmSharedStates.count)
+        XCTAssertEqual(0, mockRuntime.dispatchedEvents.count)
+
+        // Test - different consent values
+        let secondEvent = buildSecondUpdateConsentEvent()
+        mockRuntime.simulateComingEvents(secondEvent)
+
+        // Verify - events dispatched for changed consents
+        XCTAssertEqual(1, mockRuntime.createdXdmSharedStates.count)
+        XCTAssertEqual(2, mockRuntime.dispatchedEvents.count) // consent response content + edge updateConsent
+    }
+
+    func testUpdateConsentDispatchesEdgeEventWhenSameUpdateAfterTimeout() {
+        // Setup - initial consent update
+        let firstEvent = buildFirstUpdateConsentEvent()
+        mockRuntime.simulateComingEvents(firstEvent)
+        mockRuntime.resetDispatchedEventAndCreatedSharedStates()
+
+        // Need to pause to add 1 second delta to event timestamps
+        Thread.sleep(forTimeInterval: ConsentConstants.Defaults.IGNORE_CONSENT_UPDATES_INTERVAL)
+
+        // Test - same consent values
+        let firstRepeatEvent = buildFirstUpdateConsentEvent()
+        mockRuntime.simulateComingEvents(firstRepeatEvent)
+
+        // Verify - events dispatched for unchanged consents
+        XCTAssertEqual(1, mockRuntime.createdXdmSharedStates.count)
+        XCTAssertEqual(2, mockRuntime.dispatchedEvents.count)
+
+        mockRuntime.resetDispatchedEventAndCreatedSharedStates()
+
+        // Test - different consent values
+        let secondEvent = buildSecondUpdateConsentEvent()
+        mockRuntime.simulateComingEvents(secondEvent)
+
+        // Verify - events dispatched for changed consents
+        XCTAssertEqual(1, mockRuntime.createdXdmSharedStates.count)
+        XCTAssertEqual(2, mockRuntime.dispatchedEvents.count) // consent response content + edge updateConsent
+    }
+
     // MARK: Consent response event handling (consent:preferences)
 
     func testEmptyResponseNilPayload() {

--- a/Tests/UnitTests/ConsentPreferencesManagerTests.swift
+++ b/Tests/UnitTests/ConsentPreferencesManagerTests.swift
@@ -61,9 +61,9 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
         assertExactMatch(
             expected: expectedConsentsJSON,
             actual: storedConsents,
-            pathOptions: 
+            pathOptions:
                 ValueTypeMatch(paths: "consents.metadata.time"),
-                CollectionEqualCount(scope: .subtree))
+            CollectionEqualCount(scope: .subtree))
 
         // Verify current consents
         assertExactMatch(
@@ -71,7 +71,7 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             actual: currentConsents,
             pathOptions:
                 ValueTypeMatch(paths: "consents.metadata.time"),
-                CollectionEqualCount(scope: .subtree))
+            CollectionEqualCount(scope: .subtree))
     }
 
     func testMergeAndUpdateShouldReturnFalse() {
@@ -115,7 +115,7 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             actual: storedConsents,
             pathOptions:
                 ValueTypeMatch(paths: "consents.metadata.time"),
-                CollectionEqualCount(scope: .subtree))
+            CollectionEqualCount(scope: .subtree))
 
         // Verify current consents
         assertExactMatch(
@@ -123,7 +123,67 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             actual: currentConsents,
             pathOptions:
                 ValueTypeMatch(paths: "consents.metadata.time"),
-                CollectionEqualCount(scope: .subtree))
+            CollectionEqualCount(scope: .subtree))
+    }
+
+    func testMergeAndUpdateIgnoresMetadataTimeValue() {
+        // Setup
+        var manager = ConsentPreferencesManager()
+        let consents1 = [
+            "collect":
+                ["val": "n"],
+            "adID": ["val": "y"],
+            "metadata": ["time": Date().iso8601UTCWithMillisecondsString]
+        ]
+        let preferences1 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents1)!)
+
+        let consents2 = [
+            "collect":
+                ["val": "n"],
+            "adID": ["val": "y"],
+            "metadata": ["time": Date().addingTimeInterval(10000).iso8601UTCWithMillisecondsString]
+        ]
+        let preferences2 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents2)!)
+
+        // Test, second update is considered same as first even though timestamps are different
+        XCTAssertTrue(manager.mergeAndUpdate(with: preferences1))
+        XCTAssertFalse(manager.mergeAndUpdate(with: preferences2))
+
+        // Verify
+        let storedConsents = manager.persistedPreferences?.asDictionary()
+        let currentConsents = manager.currentPreferences?.asDictionary()
+
+        let expectedConsentsJSON = """
+        {
+          "consents": {
+            "adID": {
+              "val": "y"
+            },
+            "collect": {
+              "val": "n"
+            },
+            "metadata": {
+              "time": "STRING_TYPE"
+            }
+          }
+        }
+        """
+
+        // Verify stored consents
+        assertExactMatch(
+            expected: expectedConsentsJSON,
+            actual: storedConsents,
+            pathOptions:
+                ValueTypeMatch(paths: "consents.metadata.time"),
+            CollectionEqualCount(scope: .subtree))
+
+        // Verify current consents
+        assertExactMatch(
+            expected: expectedConsentsJSON,
+            actual: currentConsents,
+            pathOptions:
+                ValueTypeMatch(paths: "consents.metadata.time"),
+            CollectionEqualCount(scope: .subtree))
     }
 
     func testMergeAndUpdateMultipleMerges() {
@@ -145,19 +205,19 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
         let currentConsents = manager.currentPreferences?.asDictionary()
 
         let expectedConsentsJSON = #"""
-        {
-          "consents": {
+            {
+            "consents": {
             "adID": {
-              "val": "y"
+            "val": "y"
             },
             "collect": {
-              "val": "n"
+            "val": "n"
             },
             "metadata": {
-              "time": "STRING_TYPE"
+            "time": "STRING_TYPE"
             }
-          }
-        }
+            }
+            }
         """#
 
         // Verify stored consents
@@ -166,7 +226,7 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             actual: storedConsents,
             pathOptions:
                 ValueTypeMatch(paths: "consents.metadata.time"),
-                CollectionEqualCount(scope: .subtree))
+            CollectionEqualCount(scope: .subtree))
 
         // Verify current consents
         assertExactMatch(
@@ -174,7 +234,7 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             actual: currentConsents,
             pathOptions:
                 ValueTypeMatch(paths: "consents.metadata.time"),
-                CollectionEqualCount(scope: .subtree))
+            CollectionEqualCount(scope: .subtree))
 
         // Setup pt. 2 - Update `collect` `val` to "y"
         let date = Date()
@@ -193,19 +253,19 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
         let currentConsents_pt2 = manager.currentPreferences?.asDictionary()
 
         let expectedConsentsJSON_pt2 = #"""
-        {
-          "consents": {
+            {
+            "consents": {
             "adID": {
-              "val": "y"
+            "val": "y"
             },
             "collect": {
-              "val": "y"
+            "val": "y"
             },
             "metadata": {
-              "time": "STRING_TYPE"
+            "time": "STRING_TYPE"
             }
-          }
-        }
+            }
+            }
         """#
 
         // Verify stored consents
@@ -214,7 +274,7 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             actual: storedConsents_pt2,
             pathOptions:
                 ValueTypeMatch(paths: "consents.metadata.time"),
-                CollectionEqualCount(scope: .subtree))
+            CollectionEqualCount(scope: .subtree))
 
         // Verify current consents
         assertExactMatch(
@@ -222,7 +282,7 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             actual: currentConsents_pt2,
             pathOptions:
                 ValueTypeMatch(paths: "consents.metadata.time"),
-                CollectionEqualCount(scope: .subtree))
+            CollectionEqualCount(scope: .subtree))
     }
 
     // MARK: updateDefaults(...) tests
@@ -245,19 +305,19 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
         let defaultConsents = manager.defaultPreferences?.asDictionary()
 
         let expectedConsentsJSON = #"""
-        {
-          "consents": {
+            {
+            "consents": {
             "adID": {
-              "val": "y"
+            "val": "y"
             },
             "collect": {
-              "val": "n"
+            "val": "n"
             },
             "metadata": {
-              "time": "STRING_TYPE"
+            "time": "STRING_TYPE"
             }
-          }
-        }
+            }
+            }
         """#
 
         // Verify default consents
@@ -266,7 +326,7 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             actual: defaultConsents,
             pathOptions:
                 ValueTypeMatch(paths: "consents.metadata.time"),
-                CollectionEqualCount(scope: .subtree))
+            CollectionEqualCount(scope: .subtree))
     }
 
     func testUpdateDefaultsMultipleMerges() {
@@ -287,19 +347,19 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
         let defaultConsents = manager.defaultPreferences?.asDictionary()
 
         let expectedConsentsJSON = #"""
-        {
-          "consents": {
+            {
+            "consents": {
             "adID": {
-              "val": "y"
+            "val": "y"
             },
             "collect": {
-              "val": "n"
+            "val": "n"
             },
             "metadata": {
-              "time": "STRING_TYPE"
+            "time": "STRING_TYPE"
             }
-          }
-        }
+            }
+            }
         """#
 
         // Verify default consents
@@ -308,7 +368,7 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             actual: defaultConsents,
             pathOptions:
                 ValueTypeMatch(paths: "consents.metadata.time"),
-                CollectionEqualCount(scope: .subtree))
+            CollectionEqualCount(scope: .subtree))
 
         // Setup pt. 2 - Update removes `adID` `val`
         let date = Date()
@@ -326,16 +386,16 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
         let defaultConsents_pt2 = manager.defaultPreferences?.asDictionary()
 
         let expectedConsentsJSON_pt2 = #"""
-        {
-          "consents": {
+            {
+            "consents": {
             "collect": {
-              "val": "y"
+            "val": "y"
             },
             "metadata": {
-              "time": "STRING_TYPE"
+            "time": "STRING_TYPE"
             }
-          }
-        }
+            }
+            }
         """#
 
         // Verify default consents
@@ -344,8 +404,8 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             actual: defaultConsents_pt2,
             pathOptions:
                 ValueTypeMatch(paths: "consents.metadata.time"),
-                CollectionEqualCount(scope: .subtree),
-                KeyMustBeAbsent(paths: "consents.adID.val"))
+            CollectionEqualCount(scope: .subtree),
+            KeyMustBeAbsent(paths: "consents.adID.val"))
     }
 
     func testUpdateDefaultsWithExistingConsents_ShouldUpdate() {
@@ -375,22 +435,22 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
         let currentConsents = manager.currentPreferences?.asDictionary()
 
         let expectedConsentsJSON = #"""
-        {
-          "consents": {
+            {
+            "consents": {
             "adID": {
-              "val": "y"
+            "val": "y"
             },
             "collect": {
-              "val": "n"
+            "val": "n"
             },
             "metadata": {
-              "time": "STRING_TYPE"
+            "time": "STRING_TYPE"
             },
             "share": {
-              "val": "n"
+            "val": "n"
             }
-          }
-        }
+            }
+            }
         """#
 
         // Verify current consents
@@ -399,7 +459,7 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             actual: currentConsents,
             pathOptions:
                 ValueTypeMatch(paths: "consents.metadata.time"),
-                CollectionEqualCount(scope: .subtree))
+            CollectionEqualCount(scope: .subtree))
     }
 
     func testUpdateDefaultsWithExistingConsents_ShouldNotUpdate() {
@@ -429,19 +489,19 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
         let currentConsents = manager.currentPreferences?.asDictionary()
 
         let expectedConsentsJSON = #"""
-        {
-          "consents": {
+            {
+            "consents": {
             "adID": {
-              "val": "y"
+            "val": "y"
             },
             "collect": {
-              "val": "n"
+            "val": "n"
             },
             "metadata": {
-              "time": "STRING_TYPE"
+            "time": "STRING_TYPE"
             }
-          }
-        }
+            }
+            }
         """#
 
         // Verify current consents
@@ -450,7 +510,7 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             actual: currentConsents,
             pathOptions:
                 ValueTypeMatch(paths: "consents.metadata.time"),
-                CollectionEqualCount(scope: .subtree))
+            CollectionEqualCount(scope: .subtree))
     }
 
     func testUpdateDefaults_RemovalOfDefaultConsent() {
@@ -483,13 +543,13 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
         var currentConsents = manager.currentPreferences?.asDictionary()
 
         let expectedConsentsJSON = #"""
-        {
-          "consents": {
+            {
+            "consents": {
             "collect": {
-              "val": "y"
+            "val": "y"
             }
-          }
-        }
+            }
+            }
         """#
 
         // Verify current consents
@@ -498,6 +558,6 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             actual: currentConsents,
             pathOptions:
                 KeyMustBeAbsent(paths: "consents.adID.val"),
-                CollectionEqualCount(scope: .subtree))
+            CollectionEqualCount(scope: .subtree))
     }
 }

--- a/Tests/UnitTests/ConsentPreferencesTests.swift
+++ b/Tests/UnitTests/ConsentPreferencesTests.swift
@@ -417,6 +417,79 @@ class ConsentPreferencesTests: XCTestCase, AnyCodableAsserts {
         XCTAssertTrue(equal)
     }
 
+    // MARK: equals operator tests
+
+    func testEqualsWithEqualConsentPreferences() {
+        // Setup
+        let consents = [
+            "adID": ["val": "y"],
+            "collect": ["val": "n"],
+            "metadata": ["time": Date().iso8601UTCWithMillisecondsString]
+        ]
+        let preferences1 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents)!)
+        let preferences2 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents)!)
+
+        // Test
+        XCTAssertTrue(preferences1 == preferences2)
+    }
+
+    func testEqualsWithDifferentConsentPreferences() {
+        // Setup
+        let consents1 = [
+            "adID": ["val": "y"],
+            "collect": ["val": "n"]
+        ]
+        let preferences1 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents1)!)
+        let consents2 = [
+            "adID": ["val": "y"],
+            "collect": ["val": "y"]
+        ]
+        let preferences2 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents2)!)
+
+        // Test
+        XCTAssertFalse(preferences1 == preferences2)
+    }
+
+    func testEqualsWithDifferentDictionaryOrder() {
+        // Setup
+        let timestamp = Date().iso8601UTCWithMillisecondsString
+        let consents1 = [
+            "adID": ["val": "y"],
+            "collect": ["val": "n"],
+            "metadata": ["time": timestamp]
+        ]
+        let consents2 = [
+            "collect": ["val": "n"],
+            "adID": ["val": "y"],
+            "metadata": ["time": timestamp]
+        ]
+        let preferences1 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents1)!)
+        let preferences2 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents2)!)
+
+        // Test
+        XCTAssertTrue(preferences1 == preferences2)
+    }
+
+    func testEqualsDifferentTimestamp() {
+        // Setup
+        let consents1 = [
+            "adID": ["val": "y"],
+            "collect": ["val": "n"],
+            "metadata": ["time": Date().iso8601UTCWithMillisecondsString]
+        ]
+        let consents2 = [
+            "adID": ["val": "y"],
+            "collect": ["val": "n"],
+            "metadata": ["time": Date().addingTimeInterval(10).iso8601UTCWithMillisecondsString]
+        ]
+        let preferences1 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents1)!)
+        let preferences2 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents2)!)
+
+        // Test
+        // Expect true because equality ignores timestamp
+        XCTAssertTrue(preferences1 == preferences2)
+    }
+
     // MARK: from(config) tests
 
     func testFromEmptyConfig() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add a simple optimization to Consent to reduce calls to the Edge Network. On Consent.update() calls, if the consent preferences have not changed and the request is within 1 second of the previously synced update request, ignore the request event. This optimization helps in cases where an application quickly calls the Consent.update() API with the same values.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
