### PR TITLE
Update ConsentPreferences.merge to handle nested preferences.

### DIFF
--- a/Sources/ConsentPreferences.swift
+++ b/Sources/ConsentPreferences.swift
@@ -52,17 +52,18 @@ struct ConsentPreferences: Codable, Equatable {
         var result = base
 
         for (key, value) in other {
-            if let existingValue = result[key] {
-                // If both values are dictionaries, merge them recursively
-                if let existingDict = existingValue as? [String: Any],
-                   let newDict = value as? [String: Any] {
-                    result[key] = deepMerge(existingDict, with: newDict)
-                } else {
-                    // If they're not both dictionaries, the new value takes precedence
-                    result[key] = value
-                }
-            } else {
+            guard let existingValue = result[key] else {
                 // Key doesn't exist in base, add it
+                result[key] = value
+                continue
+            }
+
+            // If both values are dictionaries, merge them recursively
+            if let existingDict = existingValue as? [String: Any],
+               let newDict = value as? [String: Any] {
+                result[key] = deepMerge(existingDict, with: newDict)
+            } else {
+                // If they're not both dictionaries, the new value takes precedence
                 result[key] = value
             }
         }

--- a/Sources/ConsentPreferences.swift
+++ b/Sources/ConsentPreferences.swift
@@ -30,8 +30,44 @@ struct ConsentPreferences: Codable, Equatable {
     /// - Returns: The resulting `ConsentPreferences` after merging `self` with `otherPreferences`
     func merge(with otherPreferences: ConsentPreferences?) -> ConsentPreferences {
         guard let otherPreferences = otherPreferences else { return self }
-        let mergedConsents = consents.merging(otherPreferences.consents) { _, new in new }
+
+        // Convert to regular dictionaries for easier manipulation
+        let selfDict = consents.asDictionary() ?? [:]
+        let otherDict = otherPreferences.consents.asDictionary() ?? [:]
+
+        // Perform deep merge
+        let mergedDict = deepMerge(selfDict, with: otherDict)
+
+        // Convert back to AnyCodable dictionary
+        let mergedConsents = AnyCodable.from(dictionary: mergedDict) ?? [:]
         return ConsentPreferences(consents: mergedConsents)
+    }
+
+    /// Recursively merges two dictionaries, preserving nested structure
+    /// - Parameters:
+    ///   - base: The base dictionary to merge into
+    ///   - other: The dictionary to merge from
+    /// - Returns: The merged dictionary
+    private func deepMerge(_ base: [String: Any], with other: [String: Any]) -> [String: Any] {
+        var result = base
+
+        for (key, value) in other {
+            if let existingValue = result[key] {
+                // If both values are dictionaries, merge them recursively
+                if let existingDict = existingValue as? [String: Any],
+                   let newDict = value as? [String: Any] {
+                    result[key] = deepMerge(existingDict, with: newDict)
+                } else {
+                    // If they're not both dictionaries, the new value takes precedence
+                    result[key] = value
+                }
+            } else {
+                // Key doesn't exist in base, add it
+                result[key] = value
+            }
+        }
+
+        return result
     }
 
     /// Sets the provided date as metadata time for current consent preferences

--- a/Sources/ConsentPreferences.swift
+++ b/Sources/ConsentPreferences.swift
@@ -49,26 +49,13 @@ struct ConsentPreferences: Codable, Equatable {
     ///   - other: The dictionary to merge from
     /// - Returns: The merged dictionary
     private func deepMerge(_ base: [String: Any], with other: [String: Any]) -> [String: Any] {
-        var result = base
-
-        for (key, value) in other {
-            guard let existingValue = result[key] else {
-                // Key doesn't exist in base, add it
-                result[key] = value
-                continue
+        return base.merging(other) { lhs, rhs in
+            if let lhsDict = lhs as? [String: Any],
+               let rhsDict = rhs as? [String: Any] {
+                return deepMerge(lhsDict, with: rhsDict)
             }
-
-            // If both values are dictionaries, merge them recursively
-            if let existingDict = existingValue as? [String: Any],
-               let newDict = value as? [String: Any] {
-                result[key] = deepMerge(existingDict, with: newDict)
-            } else {
-                // If they're not both dictionaries, the new value takes precedence
-                result[key] = value
-            }
+            return rhs
         }
-
-        return result
     }
 
     /// Sets the provided date as metadata time for current consent preferences

--- a/Tests/UnitTests/ConsentPreferencesManagerTests.swift
+++ b/Tests/UnitTests/ConsentPreferencesManagerTests.swift
@@ -74,6 +74,59 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             CollectionEqualCount(scope: .subtree))
     }
 
+    func testMergeAndUpdateNestedPreferences() {
+        // Setup
+        var manager = ConsentPreferencesManager()
+        let consents = [
+            "collect": ["val": "n"],
+            "marketing": ["preferred": "none", "push": ["val": "y"]],
+            "metadata": ["time": Date().iso8601UTCWithMillisecondsString]
+        ]
+        let preferences = ConsentPreferences(consents: AnyCodable.from(dictionary: consents)!)
+
+        // Test
+        XCTAssertTrue(manager.mergeAndUpdate(with: preferences))
+
+        // Verify
+        let storedConsents = manager.persistedPreferences?.asDictionary()
+        let currentConsents = manager.currentPreferences?.asDictionary()
+
+        let expectedConsentsJSON = """
+        {
+          "consents": {
+            "collect": {
+              "val": "n"
+            },
+            "marketing": {
+              "preferred": "none",
+              "push": {
+                "val": "y"
+              }
+            },
+            "metadata": {
+              "time": "STRING_TYPE"
+            }
+          }
+        }
+        """
+
+        // Verify stored consents
+        assertExactMatch(
+            expected: expectedConsentsJSON,
+            actual: storedConsents,
+            pathOptions:
+                ValueTypeMatch(paths: "consents.metadata.time"),
+            CollectionEqualCount(scope: .subtree))
+
+        // Verify current consents
+        assertExactMatch(
+            expected: expectedConsentsJSON,
+            actual: currentConsents,
+            pathOptions:
+                ValueTypeMatch(paths: "consents.metadata.time"),
+            CollectionEqualCount(scope: .subtree))
+    }
+
     func testMergeAndUpdateShouldReturnFalse() {
         // Setup
         var manager = ConsentPreferencesManager()
@@ -267,6 +320,111 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             }
             }
         """#
+
+        // Verify stored consents
+        assertExactMatch(
+            expected: expectedConsentsJSON_pt2,
+            actual: storedConsents_pt2,
+            pathOptions:
+                ValueTypeMatch(paths: "consents.metadata.time"),
+            CollectionEqualCount(scope: .subtree))
+
+        // Verify current consents
+        assertExactMatch(
+            expected: expectedConsentsJSON_pt2,
+            actual: currentConsents_pt2,
+            pathOptions:
+                ValueTypeMatch(paths: "consents.metadata.time"),
+            CollectionEqualCount(scope: .subtree))
+    }
+
+    func testMergeAndUpdateMultipleMergesNestedPreferences() {
+        // Setup pt. 1
+        var manager = ConsentPreferencesManager()
+        let consents = [
+            "collect": ["val": "n"],
+            "marketing": ["preferred": "none", "push": ["val": "y"]],
+            "metadata": ["time": Date().iso8601UTCWithMillisecondsString]
+        ]
+        let preferences = ConsentPreferences(consents: AnyCodable.from(dictionary: consents)!)
+
+        // Test pt. 1
+        XCTAssertTrue(manager.mergeAndUpdate(with: preferences))
+
+        // Verify pt. 1
+        let storedConsents = manager.persistedPreferences?.asDictionary()
+        let currentConsents = manager.currentPreferences?.asDictionary()
+
+        let expectedConsentsJSON = """
+        {
+          "consents": {
+            "collect": {
+              "val": "n"
+            },
+            "marketing": {
+              "preferred": "none",
+              "push": {
+                "val": "y"
+              }
+            },
+            "metadata": {
+              "time": "STRING_TYPE"
+            }
+          }
+        }
+        """
+
+        // Verify stored consents
+        assertExactMatch(
+            expected: expectedConsentsJSON,
+            actual: storedConsents,
+            pathOptions:
+                ValueTypeMatch(paths: "consents.metadata.time"),
+            CollectionEqualCount(scope: .subtree))
+
+        // Verify current consents
+        assertExactMatch(
+            expected: expectedConsentsJSON,
+            actual: currentConsents,
+            pathOptions:
+                ValueTypeMatch(paths: "consents.metadata.time"),
+            CollectionEqualCount(scope: .subtree))
+
+        // Setup pt. 2 - Update `marketing` `preferred` to `sms` and add `sms` `val` to "y"
+        let consents_pt2 = [
+            "marketing": ["preferred": "sms", "sms": ["val": "y"]],
+            "metadata": ["time": Date().iso8601UTCWithMillisecondsString]
+        ]
+        let preferences_pt2 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents_pt2)!)
+
+        // Test pt. 2
+        XCTAssertTrue(manager.mergeAndUpdate(with: preferences_pt2))
+
+        // Verify pt. 2
+        let storedConsents_pt2 = manager.persistedPreferences?.asDictionary()
+        let currentConsents_pt2 = manager.currentPreferences?.asDictionary()
+
+        let expectedConsentsJSON_pt2 = """
+        {
+          "consents": {
+            "collect": {
+              "val": "n"
+            },
+            "marketing": {
+              "preferred": "sms",
+              "push": {
+                "val": "y"
+              },
+              "sms": {
+                "val": "y"
+              }
+            },
+            "metadata": {
+              "time": "STRING_TYPE"
+            }
+          }
+        }
+        """
 
         // Verify stored consents
         assertExactMatch(

--- a/Tests/UnitTests/ConsentPreferencesTests.swift
+++ b/Tests/UnitTests/ConsentPreferencesTests.swift
@@ -417,34 +417,109 @@ class ConsentPreferencesTests: XCTestCase, AnyCodableAsserts {
         XCTAssertTrue(equal)
     }
 
-    // MARK: equals operator tests
-
-    func testEqualsWithEqualConsentPreferences() {
+    func testMergeWithNestedConsentsPreferences() {
         // Setup
         let consents = [
-            "adID": ["val": "y"],
-            "collect": ["val": "n"],
+            "collect": ["val": "y"],
+            "marketing": ["preferred": "none", "email": ["val": "y"]],
             "metadata": ["time": Date().iso8601UTCWithMillisecondsString]
         ]
-        let preferences1 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents)!)
-        let preferences2 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents)!)
+        let preferences = ConsentPreferences(consents: AnyCodable.from(dictionary: consents)!)
+
+        let date = Date()
+        let otherConsents = [
+            "marketing": ["preferred": "push", "push": ["val": "y"]],
+            "metadata": ["time": date.iso8601UTCWithMillisecondsString]
+        ]
+        let otherPreferences = ConsentPreferences(consents: AnyCodable.from(dictionary: otherConsents)!)
+
+        // Test
+        let mergedPreferences = preferences.merge(with: otherPreferences)
+
+        // Verify
+        let expectedConsents = [
+            "collect": ["val": "y"],
+            "marketing": ["preferred": "push", "push": ["val": "y"], "email": ["val": "y"]],
+            "metadata": ["time": date.iso8601UTCWithMillisecondsString]
+        ]
+        let expectedPreferences = ConsentPreferences(consents: AnyCodable.from(dictionary: expectedConsents)!)
+
+        let equal = NSDictionary(dictionary: AnyCodable.toAnyDictionary(dictionary: mergedPreferences.consents)!).isEqual(to: AnyCodable.toAnyDictionary(dictionary: expectedPreferences.consents)!)
+        XCTAssertTrue(equal)
+    }
+
+    // MARK: equals operator tests
+
+    func testEqualsWithEqualConsentPreferencesSimple() {
+        // Setup
+        let consents = [
+            "consents": [
+                "adID": ["val": "y"],
+                "collect": ["val": "n"],
+                "metadata": ["time": Date().iso8601UTCWithMillisecondsString]
+            ]
+        ]
+        let preferences1 = ConsentPreferences.from(eventData: consents)
+        let preferences2 = ConsentPreferences.from(eventData: consents)
 
         // Test
         XCTAssertTrue(preferences1 == preferences2)
     }
 
-    func testEqualsWithDifferentConsentPreferences() {
+    func testEqualsWithEqualConsentPreferencesNested() {
+        // Setup
+        let consents = [
+            "consents": [
+                "collect": ["val": "n"],
+                "marketing": ["preferred": "push", "push": ["val": "y"], "email": ["val": "y"]],
+                "metadata": ["time": Date().iso8601UTCWithMillisecondsString]
+            ]
+        ]
+        let preferences1 = ConsentPreferences.from(eventData: consents)
+        let preferences2 = ConsentPreferences.from(eventData: consents)
+        // Test
+        XCTAssertTrue(preferences1 == preferences2)
+    }
+
+    func testEqualsWithDifferentConsentPreferencesSimple() {
         // Setup
         let consents1 = [
-            "adID": ["val": "y"],
-            "collect": ["val": "n"]
+            "consents": [
+                "adID": ["val": "y"],
+                "collect": ["val": "n"]
+            ]
         ]
-        let preferences1 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents1)!)
+        let preferences1 = ConsentPreferences.from(eventData: consents1)
         let consents2 = [
-            "adID": ["val": "y"],
-            "collect": ["val": "y"]
+            "consents": [
+                "adID": ["val": "y"],
+                "collect": ["val": "y"]
+            ]
         ]
-        let preferences2 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents2)!)
+        let preferences2 = ConsentPreferences.from(eventData: consents2)
+
+        // Test
+        XCTAssertFalse(preferences1 == preferences2)
+    }
+
+    func testEqualsWithDifferentConsentPreferencesNested() {
+        // Setup
+        let consents1 = [
+            "consents": [
+                "adID": ["val": "y"],
+                "collect": ["val": "y"],
+                "marketing": ["preferred": "push", "push": ["val": "y"], "email": ["val": "y"]] // email is 'y'
+            ]
+        ]
+        let preferences1 = ConsentPreferences.from(eventData: consents1)
+        let consents2 = [
+            "consents": [
+                "adID": ["val": "y"],
+                "collect": ["val": "y"],
+                "marketing": ["preferred": "push", "push": ["val": "y"], "email": ["val": "n"]]  // email is 'n'
+            ]
+        ]
+        let preferences2 = ConsentPreferences.from(eventData: consents2)
 
         // Test
         XCTAssertFalse(preferences1 == preferences2)
@@ -454,17 +529,21 @@ class ConsentPreferencesTests: XCTestCase, AnyCodableAsserts {
         // Setup
         let timestamp = Date().iso8601UTCWithMillisecondsString
         let consents1 = [
-            "adID": ["val": "y"],
-            "collect": ["val": "n"],
-            "metadata": ["time": timestamp]
+            "consents": [
+                "adID": ["val": "y"],
+                "collect": ["val": "n"],
+                "metadata": ["time": timestamp]
+            ]
         ]
         let consents2 = [
-            "collect": ["val": "n"],
-            "adID": ["val": "y"],
-            "metadata": ["time": timestamp]
+            "consents": [
+                "collect": ["val": "n"],
+                "adID": ["val": "y"],
+                "metadata": ["time": timestamp]
+            ]
         ]
-        let preferences1 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents1)!)
-        let preferences2 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents2)!)
+        let preferences1 = ConsentPreferences.from(eventData: consents1)
+        let preferences2 = ConsentPreferences.from(eventData: consents2)
 
         // Test
         XCTAssertTrue(preferences1 == preferences2)
@@ -473,18 +552,21 @@ class ConsentPreferencesTests: XCTestCase, AnyCodableAsserts {
     func testEqualsDifferentTimestamp() {
         // Setup
         let consents1 = [
-            "adID": ["val": "y"],
-            "collect": ["val": "n"],
-            "metadata": ["time": Date().iso8601UTCWithMillisecondsString]
+            "consents": [
+                "adID": ["val": "y"],
+                "collect": ["val": "n"],
+                "metadata": ["time": Date().iso8601UTCWithMillisecondsString]
+            ]
         ]
         let consents2 = [
-            "adID": ["val": "y"],
-            "collect": ["val": "n"],
-            "metadata": ["time": Date().addingTimeInterval(10).iso8601UTCWithMillisecondsString]
+            "consents": [
+                "adID": ["val": "y"],
+                "collect": ["val": "n"],
+                "metadata": ["time": Date().addingTimeInterval(10).iso8601UTCWithMillisecondsString]
+            ]
         ]
-        let preferences1 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents1)!)
-        let preferences2 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents2)!)
-
+        let preferences1 = ConsentPreferences.from(eventData: consents1)
+        let preferences2 = ConsentPreferences.from(eventData: consents2)
         // Test
         // Expect true because equality ignores timestamp
         XCTAssertTrue(preferences1 == preferences2)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix support of nested maps in Consent preferences. Changes the `ConsentPreferences.merge` function to deep merge the map structures when updating preferences.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
