### PR TITLE
Release v5.0.1

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   build-and-test:
     name: "CI"
-    uses: adobe/aepsdk-commons/.github/workflows/ios-build-and-test.yml@gha-ios-5.2.0
+    uses: adobe/aepsdk-commons/.github/workflows/ios-build-and-test.yml@gha-ios-5.3.3
     with:
       ios-device-names: '["iPhone 15"]'
       ios-versions: '["18.1"]'
@@ -30,4 +30,5 @@ jobs:
       run-test-tvos-functional: true
       run-build-xcframework-and-app: true
       enable-codecov: true
+      result-bundle-path: build/reports
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
   release:
     permissions:
         contents: write
-    uses: adobe/aepsdk-commons/.github/workflows/ios-release.yml@gha-ios-5.2.0
+    uses: adobe/aepsdk-commons/.github/workflows/ios-release.yml@gha-ios-5.3.3
     with:
       tag: ${{ github.event.inputs.tag }}
       create-github-release: ${{ github.event.inputs.create-github-release == 'true' && 'AEPEdgeConsent' || '' }}

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -42,7 +42,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: adobe/aepsdk-commons/.github/workflows/versions.yml@gha-ios-5.2.0
+    uses: adobe/aepsdk-commons/.github/workflows/versions.yml@gha-ios-5.3.3
     with:
       version: ${{ github.event.inputs.version }}
       branch: ${{ github.event.inputs.branch }}

--- a/AEPEdgeConsent.podspec
+++ b/AEPEdgeConsent.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "AEPEdgeConsent"
-  s.version          = "5.0.0"
+  s.version          = "5.0.1"
   s.summary          = "Experience Platform Consent Collection extension for Adobe Experience Platform Mobile SDK. Written and maintained by Adobe."
 
   s.description      = <<-DESC

--- a/AEPEdgeConsent.xcodeproj/project.pbxproj
+++ b/AEPEdgeConsent.xcodeproj/project.pbxproj
@@ -1289,7 +1289,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.0.0;
+				MARKETING_VERSION = 5.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.edge.consent;
 				PRODUCT_MODULE_NAME = AEPEdgeConsent;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1322,7 +1322,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.0.0;
+				MARKETING_VERSION = 5.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.edge.consent;
 				PRODUCT_MODULE_NAME = AEPEdgeConsent;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/Makefile
+++ b/Makefile
@@ -37,29 +37,6 @@ else
 	TVOS_DESTINATION = "platform=tvOS Simulator,name=$(TVOS_DEVICE_NAME),OS=$(TVOS_VERSION)"
 endif
 
-clean-derived-data:
-	@if [ -z "$(SCHEME)" ]; then \
-		echo "Error: SCHEME variable is not set."; \
-		exit 1; \
-	fi; \
-	if [ -z "$(DESTINATION)" ]; then \
-		echo "Error: DESTINATION variable is not set."; \
-		exit 1; \
-	fi; \
-	echo "Cleaning derived data for scheme: $(SCHEME) with destination: $(DESTINATION)"; \
-	DERIVED_DATA_PATH=`xcodebuild -workspace $(PROJECT_NAME).xcworkspace -scheme "$(SCHEME)" -destination "$(DESTINATION)" -showBuildSettings | grep -m1 'BUILD_DIR' | awk '{print $$3}' | sed 's|/Build/Products||'`; \
-	echo "DerivedData Path: $$DERIVED_DATA_PATH"; \
-	\
-	LOGS_TEST_DIR=$$DERIVED_DATA_PATH/Logs/Test; \
-	echo "Logs Test Path: $$LOGS_TEST_DIR"; \
-	\
-	if [ -d "$$LOGS_TEST_DIR" ]; then \
-		echo "Removing existing .xcresult files in $$LOGS_TEST_DIR"; \
-		rm -rf "$$LOGS_TEST_DIR"/*.xcresult; \
-	else \
-		echo "Logs/Test directory does not exist. Skipping cleanup."; \
-	fi;
-
 setup:
 	pod install
 
@@ -68,11 +45,8 @@ setup-tools: install-githook
 clean:
 	rm -rf build
 
-clean-ios-test-files:
-	rm -rf iosresults.xcresult
-
-clean-tvos-test-files:
-	rm -rf tvosresults.xcresult
+clean-test-files:
+	rm -rf build/reports
 
 pod-repo-update:
 	pod repo update
@@ -107,15 +81,15 @@ build-ios:
 	@echo "######################################################################"
 	@echo "### Building iOS archive"
 	@echo "######################################################################"
-	xcodebuild archive -workspace $(PROJECT_NAME).xcworkspace -scheme $(SCHEME_NAME_XCFRAMEWORK) -archivePath "./build/ios.xcarchive" -sdk iphoneos -destination="iOS" SKIP_INSTALL=NO BUILD_LIBRARIES_FOR_DISTRIBUTION=YES ADB_SKIP_LINT=YES
-	xcodebuild archive -workspace $(PROJECT_NAME).xcworkspace -scheme $(SCHEME_NAME_XCFRAMEWORK) -archivePath "./build/ios_simulator.xcarchive" -sdk iphonesimulator -destination="iOS Simulator" SKIP_INSTALL=NO BUILD_LIBRARIES_FOR_DISTRIBUTION=YES ADB_SKIP_LINT=YES
+	xcodebuild archive -workspace $(PROJECT_NAME).xcworkspace -scheme $(SCHEME_NAME_XCFRAMEWORK) -archivePath "./build/ios.xcarchive" -sdk iphoneos -destination="iOS" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES ADB_SKIP_LINT=YES
+	xcodebuild archive -workspace $(PROJECT_NAME).xcworkspace -scheme $(SCHEME_NAME_XCFRAMEWORK) -archivePath "./build/ios_simulator.xcarchive" -sdk iphonesimulator -destination="iOS Simulator" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES ADB_SKIP_LINT=YES
 
 build-tvos:
 	@echo "######################################################################"
 	@echo "### Building tvOS archive"
 	@echo "######################################################################"
-	xcodebuild archive -workspace $(PROJECT_NAME).xcworkspace -scheme $(SCHEME_NAME_XCFRAMEWORK) -archivePath "./build/tvos.xcarchive" -sdk appletvos -destination="tvOS" SKIP_INSTALL=NO BUILD_LIBRARIES_FOR_DISTRIBUTION=YES ADB_SKIP_LINT=YES
-	xcodebuild archive -workspace $(PROJECT_NAME).xcworkspace -scheme $(SCHEME_NAME_XCFRAMEWORK) -archivePath "./build/tvos_simulator.xcarchive" -sdk appletvsimulator -destination="tvOS Simulator" SKIP_INSTALL=NO BUILD_LIBRARIES_FOR_DISTRIBUTION=YES ADB_SKIP_LINT=YES
+	xcodebuild archive -workspace $(PROJECT_NAME).xcworkspace -scheme $(SCHEME_NAME_XCFRAMEWORK) -archivePath "./build/tvos.xcarchive" -sdk appletvos -destination="tvOS" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES ADB_SKIP_LINT=YES
+	xcodebuild archive -workspace $(PROJECT_NAME).xcworkspace -scheme $(SCHEME_NAME_XCFRAMEWORK) -archivePath "./build/tvos_simulator.xcarchive" -sdk appletvsimulator -destination="tvOS Simulator" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES ADB_SKIP_LINT=YES
 
 zip:
 	cd build && zip -r -X $(PROJECT_NAME).xcframework.zip $(PROJECT_NAME).xcframework/
@@ -139,33 +113,29 @@ build-app: setup
 
 test: unit-test-ios functional-test-ios unit-test-tvos functional-test-tvos
 
-unit-test-ios:
+unit-test-ios: clean-test-files
 	@echo "######################################################################"
 	@echo "### Unit Testing iOS"
 	@echo "######################################################################"
-	@$(MAKE) clean-derived-data SCHEME=UnitTests DESTINATION=$(IOS_DESTINATION)
-	xcodebuild test -workspace $(PROJECT_NAME).xcworkspace -scheme "UnitTests" -destination $(IOS_DESTINATION) -enableCodeCoverage YES ADB_SKIP_LINT=YES
+	xcodebuild test -workspace $(PROJECT_NAME).xcworkspace -scheme "UnitTests" -destination $(IOS_DESTINATION) -derivedDataPath build/out -resultBundlePath build/reports/iosUnitResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES
 
-functional-test-ios:
+functional-test-ios: clean-test-files
 	@echo "######################################################################"
 	@echo "### Functional Testing iOS"
 	@echo "######################################################################"
-	@$(MAKE) clean-derived-data SCHEME=FunctionalTests DESTINATION=$(IOS_DESTINATION)
-	xcodebuild test -workspace $(PROJECT_NAME).xcworkspace -scheme "FunctionalTests" -destination $(IOS_DESTINATION) -enableCodeCoverage YES ADB_SKIP_LINT=YES
+	xcodebuild test -workspace $(PROJECT_NAME).xcworkspace -scheme "FunctionalTests" -destination $(IOS_DESTINATION) -derivedDataPath build/out -resultBundlePath build/reports/iosFunctionalResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES
 
-unit-test-tvos:
+unit-test-tvos: clean-test-files
 	@echo "######################################################################"
 	@echo "### Unit Testing tvOS"
 	@echo "######################################################################"
-	@$(MAKE) clean-derived-data SCHEME=UnitTests DESTINATION=$(TVOS_DESTINATION)
-	xcodebuild test -workspace $(PROJECT_NAME).xcworkspace -scheme "UnitTests" -destination $(TVOS_DESTINATION) -enableCodeCoverage YES ADB_SKIP_LINT=YES
+	xcodebuild test -workspace $(PROJECT_NAME).xcworkspace -scheme "UnitTests" -destination $(TVOS_DESTINATION) -derivedDataPath build/out -resultBundlePath build/reports/tvosUnitResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES
 
-functional-test-tvos:
+functional-test-tvos: clean-test-files
 	@echo "######################################################################"
 	@echo "### Functional Testing tvOS"
 	@echo "######################################################################"
-	@$(MAKE) clean-derived-data SCHEME=FunctionalTests DESTINATION=$(TVOS_DESTINATION)
-	xcodebuild test -workspace $(PROJECT_NAME).xcworkspace -scheme "FunctionalTests" -destination $(TVOS_DESTINATION) -enableCodeCoverage YES ADB_SKIP_LINT=YES
+	xcodebuild test -workspace $(PROJECT_NAME).xcworkspace -scheme "FunctionalTests" -destination $(TVOS_DESTINATION) -derivedDataPath build/out -resultBundlePath build/reports/tvosFunctionalResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES
 
 install-githook:
 	git config core.hooksPath .githooks

--- a/Podfile
+++ b/Podfile
@@ -19,12 +19,12 @@ end
 
 target 'UnitTests' do
   core_pods
-  pod 'AEPTestUtils', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :tag => 'testutils-5.2.2'
+  pod 'AEPTestUtils', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :tag => 'testutils-5.6.0'
 end
 
 target 'FunctionalTests' do
   core_pods
-  pod 'AEPTestUtils', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :tag => 'testutils-5.2.2'
+  pod 'AEPTestUtils', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :tag => 'testutils-5.6.0'
 end
 
 target 'TestApp' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,17 +1,17 @@
 PODS:
-  - AEPCore (5.3.1):
+  - AEPCore (5.6.0):
     - AEPRulesEngine (< 6.0.0, >= 5.0.0)
-    - AEPServices (< 6.0.0, >= 5.3.1)
+    - AEPServices (< 6.0.0, >= 5.6.0)
   - AEPRulesEngine (5.0.0)
-  - AEPServices (5.3.1)
-  - AEPTestUtils (5.2.2):
-    - AEPCore (< 6.0.0, >= 5.2.0)
-    - AEPServices (< 6.0.0, >= 5.2.0)
+  - AEPServices (5.6.0)
+  - AEPTestUtils (5.6.0):
+    - AEPCore (< 6.0.0, >= 5.6.0)
+    - AEPServices (< 6.0.0, >= 5.6.0)
   - SwiftLint (0.52.0)
 
 DEPENDENCIES:
   - AEPCore
-  - AEPTestUtils (from `https://github.com/adobe/aepsdk-core-ios.git`, tag `testutils-5.2.2`)
+  - AEPTestUtils (from `https://github.com/adobe/aepsdk-core-ios.git`, tag `testutils-5.6.0`)
   - SwiftLint (= 0.52.0)
 
 SPEC REPOS:
@@ -24,20 +24,20 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   AEPTestUtils:
     :git: https://github.com/adobe/aepsdk-core-ios.git
-    :tag: testutils-5.2.2
+    :tag: testutils-5.6.0
 
 CHECKOUT OPTIONS:
   AEPTestUtils:
     :git: https://github.com/adobe/aepsdk-core-ios.git
-    :tag: testutils-5.2.2
+    :tag: testutils-5.6.0
 
 SPEC CHECKSUMS:
-  AEPCore: 28191f2df03225a5e88b6f8f343f7e18a604c9ef
+  AEPCore: 404a4c600f5a885031a7e9b1e646ea9405d94b24
   AEPRulesEngine: fe5800653a4bee07b1e41e61b4d5551f0dba557b
-  AEPServices: fcba979e90f6916b066aa66f016700d7b7534d96
-  AEPTestUtils: 61de2086056f4aa3223dc7d035991ef4fdacbfdb
+  AEPServices: cbdac48662ef2f1001d05d47b5930a397a8beaab
+  AEPTestUtils: 2bbed995c8974f6f6d92058db88d6cd2e4a7f869
   SwiftLint: 13280e21cdda6786ad908dc6e416afe5acd1fcb7
 
-PODFILE CHECKSUM: 7aecc646b29f51967a41846d7da12328a2e2b213
+PODFILE CHECKSUM: 5bd9eadbcba898b67b4794cc4a090f11b86f0182
 
 COCOAPODS: 1.16.2

--- a/Sources/Consent.swift
+++ b/Sources/Consent.swift
@@ -24,6 +24,9 @@ public class Consent: NSObject, Extension {
 
     private var preferencesManager = ConsentPreferencesManager()
 
+    // The last time a consent update was processed from public API. Initialize to date in the past.
+    private var lastConsentUpdateTime: Date = Date().addingTimeInterval(-(ConsentConstants.Defaults.IGNORE_CONSENT_UPDATES_INTERVAL * 2))
+
     // MARK: Extension
 
     public required init?(runtime: ExtensionRuntime) {
@@ -81,10 +84,22 @@ public class Consent: NSObject, Extension {
 
         // set metadata
         newPreferences.setTimestamp(date: event.timestamp)
-        preferencesManager.mergeAndUpdate(with: newPreferences)
-        shareCurrentConsents(event: event)
-        // Share only changed preferences instead of all preferences to prevent accidental sharing of default consents.
-        dispatchEdgeConsentUpdateEvent(preferences: newPreferences)
+        let outsideTimeout = event.timestamp.timeIntervalSince(lastConsentUpdateTime) > ConsentConstants.Defaults.IGNORE_CONSENT_UPDATES_INTERVAL
+
+        if preferencesManager.mergeAndUpdate(with: newPreferences) || outsideTimeout {
+            shareCurrentConsents(event: event)
+            // Share only changed preferences instead of all preferences to prevent accidental sharing of default consents.
+            dispatchEdgeConsentUpdateEvent(preferences: newPreferences)
+            lastConsentUpdateTime = event.timestamp
+        } else {
+            // If the consent preferences have not changed and arrived too soon after the previous synced preferences, ignore event.
+            let msg = """
+            Consent - Update request did not change preferences and is within \
+            \(ConsentConstants.Defaults.IGNORE_CONSENT_UPDATES_INTERVAL) \
+            sec of the previous request, dropping event.
+            """
+            Log.debug(label: ConsentConstants.LOG_TAG, msg)
+        }
     }
 
     /// Invoked when an event with `EventType.edge` and source `consent:preferences` is dispatched
@@ -102,13 +117,13 @@ public class Consent: NSObject, Extension {
             return
         }
 
-        if preferencesManager.mergeAndUpdate(with: newPreferences) {
-            if newPreferences.consents[ConsentConstants.EventDataKeys.METADATA] == nil {
-                // preferences were updated without providing metadata, update the metadata
-                newPreferences.setTimestamp(date: event.timestamp)
-                preferencesManager.mergeAndUpdate(with: newPreferences) // re-apply with updated metadata
-            }
+        // Set timestamp if needed
+        if newPreferences.consents[ConsentConstants.EventDataKeys.METADATA] == nil {
+            newPreferences.setTimestamp(date: event.timestamp)
+        }
 
+        // Merge and share preferences if changed
+        if preferencesManager.mergeAndUpdate(with: newPreferences) {
             shareCurrentConsents(event: event)
         }
     }

--- a/Sources/ConsentConstants.swift
+++ b/Sources/ConsentConstants.swift
@@ -18,6 +18,11 @@ enum ConsentConstants {
     static let EXTENSION_VERSION = "5.0.0"
     static let LOG_TAG = FRIENDLY_NAME
 
+    enum Defaults {
+        /// The interval to ignore consecutive consent updates, in seconds.
+        static let IGNORE_CONSENT_UPDATES_INTERVAL: TimeInterval = 1
+    }
+
     enum EventDataKeys {
         static let CONSENTS = "consents"
         static let METADATA = "metadata"

--- a/Sources/ConsentConstants.swift
+++ b/Sources/ConsentConstants.swift
@@ -15,7 +15,7 @@ import Foundation
 enum ConsentConstants {
     static let EXTENSION_NAME = "com.adobe.edge.consent"
     static let FRIENDLY_NAME = "Consent"
-    static let EXTENSION_VERSION = "5.0.0"
+    static let EXTENSION_VERSION = "5.0.1"
     static let LOG_TAG = FRIENDLY_NAME
 
     enum Defaults {

--- a/Sources/ConsentPreferences.swift
+++ b/Sources/ConsentPreferences.swift
@@ -75,13 +75,30 @@ struct ConsentPreferences: Codable, Equatable {
         return defaultPrefs
     }
 
-    /// Determines if two `ConsentPreferences` are equal
+    /// Determines if two `ConsentPreferences` are equal.
+    /// Ignores the "consents.metadata.time" field.
     /// - Parameters:
     ///   - lhs: a `ConsentPreferences`
     ///   - rhs: a `ConsentPreferences`
     /// - Returns: true if they are equal, otherwise false
     static func == (lhs: ConsentPreferences, rhs: ConsentPreferences) -> Bool {
-        return NSDictionary(dictionary: lhs.asDictionary() ?? [:]).isEqual(to: rhs.asDictionary() ?? [:])
+        var lhsDict = lhs.asDictionary() ?? [:]
+        if var lhsConsents = lhsDict[ConsentConstants.EventDataKeys.CONSENTS] as? [String: Any],
+           var lhsMetaData = lhsConsents[ConsentConstants.EventDataKeys.METADATA] as? [String: Any] {
+            lhsMetaData.removeValue(forKey: ConsentConstants.EventDataKeys.TIME)
+            lhsConsents[ConsentConstants.EventDataKeys.METADATA] = lhsMetaData
+            lhsDict[ConsentConstants.EventDataKeys.CONSENTS] = lhsConsents
+        }
+
+        var rhsDict = rhs.asDictionary() ?? [:]
+        if var rhsConsents = rhsDict[ConsentConstants.EventDataKeys.CONSENTS] as? [String: Any],
+           var rhsMetaData = rhsConsents[ConsentConstants.EventDataKeys.METADATA] as? [String: Any] {
+            rhsMetaData.removeValue(forKey: ConsentConstants.EventDataKeys.TIME)
+            rhsConsents[ConsentConstants.EventDataKeys.METADATA] = rhsMetaData
+            rhsDict[ConsentConstants.EventDataKeys.CONSENTS] = rhsConsents
+        }
+
+        return NSDictionary(dictionary: lhsDict).isEqual(to: rhsDict)
     }
 
 }

--- a/Sources/ConsentPreferences.swift
+++ b/Sources/ConsentPreferences.swift
@@ -30,8 +30,32 @@ struct ConsentPreferences: Codable, Equatable {
     /// - Returns: The resulting `ConsentPreferences` after merging `self` with `otherPreferences`
     func merge(with otherPreferences: ConsentPreferences?) -> ConsentPreferences {
         guard let otherPreferences = otherPreferences else { return self }
-        let mergedConsents = consents.merging(otherPreferences.consents) { _, new in new }
+
+        // Convert to regular dictionaries for easier manipulation
+        let selfDict = consents.asDictionary() ?? [:]
+        let otherDict = otherPreferences.consents.asDictionary() ?? [:]
+
+        // Perform deep merge
+        let mergedDict = deepMerge(selfDict, with: otherDict)
+
+        // Convert back to AnyCodable dictionary
+        let mergedConsents = AnyCodable.from(dictionary: mergedDict) ?? [:]
         return ConsentPreferences(consents: mergedConsents)
+    }
+
+    /// Recursively merges two dictionaries, preserving nested structure
+    /// - Parameters:
+    ///   - base: The base dictionary to merge into
+    ///   - other: The dictionary to merge from
+    /// - Returns: The merged dictionary
+    private func deepMerge(_ base: [String: Any], with other: [String: Any]) -> [String: Any] {
+        return base.merging(other) { lhs, rhs in
+            if let lhsDict = lhs as? [String: Any],
+               let rhsDict = rhs as? [String: Any] {
+                return deepMerge(lhsDict, with: rhsDict)
+            }
+            return rhs
+        }
     }
 
     /// Sets the provided date as metadata time for current consent preferences

--- a/Tests/FunctionalTests/ConsentFunctionalTests.swift
+++ b/Tests/FunctionalTests/ConsentFunctionalTests.swift
@@ -629,6 +629,71 @@ class ConsentFunctionalTests: XCTestCase, AnyCodableAsserts {
             pathOptions: KeyMustBeAbsent(paths: "consents.adID.val"), CollectionEqualCount(scope: .subtree))
     }
 
+    func testUpdateConsentDoesNotDispatchEdgeEventWhenSameUpdateLessThanTimeout() {
+        // Setup - initial consent update
+        let firstEvent = buildFirstUpdateConsentEvent()
+        mockRuntime.simulateComingEvents(firstEvent)
+        mockRuntime.resetDispatchedEventAndCreatedSharedStates()
+
+        // Test - same consent values
+        mockRuntime.simulateComingEvents(firstEvent)
+
+        // Verify - no events dispatched for unchanged consents as event timestamps are equal.
+        XCTAssertEqual(0, mockRuntime.createdXdmSharedStates.count)
+        XCTAssertEqual(0, mockRuntime.dispatchedEvents.count)
+
+        // Test - different consent values
+        let secondEvent = buildSecondUpdateConsentEvent()
+        mockRuntime.simulateComingEvents(secondEvent)
+
+        // Verify - events dispatched for changed consents
+        XCTAssertEqual(1, mockRuntime.createdXdmSharedStates.count)
+        XCTAssertEqual(2, mockRuntime.dispatchedEvents.count) // consent response content + edge updateConsent
+    }
+
+    func testUpdateConsentDispatchesEdgeEventWhenDifferentUpdateLessThanTimeout() {
+        // Setup - initial consent update
+        let firstEvent = buildFirstUpdateConsentEvent()
+        mockRuntime.simulateComingEvents(firstEvent)
+        mockRuntime.resetDispatchedEventAndCreatedSharedStates()
+
+        // Test - different consent values
+        let secondEvent = buildSecondUpdateConsentEvent()
+        mockRuntime.simulateComingEvents(secondEvent)
+
+        // Verify - events dispatched for changed consents within timeout
+        XCTAssertEqual(1, mockRuntime.createdXdmSharedStates.count)
+        XCTAssertEqual(2, mockRuntime.dispatchedEvents.count)
+    }
+
+    func testUpdateConsentDispatchesEdgeEventWhenSameUpdateAfterTimeout() {
+        // Setup - initial consent update
+        let firstEvent = buildFirstUpdateConsentEvent()
+        mockRuntime.simulateComingEvents(firstEvent)
+        mockRuntime.resetDispatchedEventAndCreatedSharedStates()
+
+        // Need to pause to add 1 second delta to event timestamps
+        Thread.sleep(forTimeInterval: ConsentConstants.Defaults.IGNORE_CONSENT_UPDATES_INTERVAL)
+
+        // Test - same consent values
+        let firstRepeatEvent = buildFirstUpdateConsentEvent()
+        mockRuntime.simulateComingEvents(firstRepeatEvent)
+
+        // Verify - events dispatched for unchanged consents
+        XCTAssertEqual(1, mockRuntime.createdXdmSharedStates.count)
+        XCTAssertEqual(2, mockRuntime.dispatchedEvents.count)
+
+        mockRuntime.resetDispatchedEventAndCreatedSharedStates()
+
+        // Test - different consent values
+        let secondEvent = buildSecondUpdateConsentEvent()
+        mockRuntime.simulateComingEvents(secondEvent)
+
+        // Verify - events dispatched for changed consents
+        XCTAssertEqual(1, mockRuntime.createdXdmSharedStates.count)
+        XCTAssertEqual(2, mockRuntime.dispatchedEvents.count) // consent response content + edge updateConsent
+    }
+
     // MARK: Consent response event handling (consent:preferences)
 
     func testEmptyResponseNilPayload() {

--- a/Tests/UnitTests/ConsentPreferencesManagerTests.swift
+++ b/Tests/UnitTests/ConsentPreferencesManagerTests.swift
@@ -61,9 +61,9 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
         assertExactMatch(
             expected: expectedConsentsJSON,
             actual: storedConsents,
-            pathOptions: 
+            pathOptions:
                 ValueTypeMatch(paths: "consents.metadata.time"),
-                CollectionEqualCount(scope: .subtree))
+            CollectionEqualCount(scope: .subtree))
 
         // Verify current consents
         assertExactMatch(
@@ -71,7 +71,7 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             actual: currentConsents,
             pathOptions:
                 ValueTypeMatch(paths: "consents.metadata.time"),
-                CollectionEqualCount(scope: .subtree))
+            CollectionEqualCount(scope: .subtree))
     }
 
     func testMergeAndUpdateShouldReturnFalse() {
@@ -115,7 +115,7 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             actual: storedConsents,
             pathOptions:
                 ValueTypeMatch(paths: "consents.metadata.time"),
-                CollectionEqualCount(scope: .subtree))
+            CollectionEqualCount(scope: .subtree))
 
         // Verify current consents
         assertExactMatch(
@@ -123,7 +123,67 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             actual: currentConsents,
             pathOptions:
                 ValueTypeMatch(paths: "consents.metadata.time"),
-                CollectionEqualCount(scope: .subtree))
+            CollectionEqualCount(scope: .subtree))
+    }
+
+    func testMergeAndUpdateIgnoresMetadataTimeValue() {
+        // Setup
+        var manager = ConsentPreferencesManager()
+        let consents1 = [
+            "collect":
+                ["val": "n"],
+            "adID": ["val": "y"],
+            "metadata": ["time": Date().iso8601UTCWithMillisecondsString]
+        ]
+        let preferences1 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents1)!)
+
+        let consents2 = [
+            "collect":
+                ["val": "n"],
+            "adID": ["val": "y"],
+            "metadata": ["time": Date().addingTimeInterval(10000).iso8601UTCWithMillisecondsString]
+        ]
+        let preferences2 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents2)!)
+
+        // Test, second update is considered same as first even though timestamps are different
+        XCTAssertTrue(manager.mergeAndUpdate(with: preferences1))
+        XCTAssertFalse(manager.mergeAndUpdate(with: preferences2))
+
+        // Verify
+        let storedConsents = manager.persistedPreferences?.asDictionary()
+        let currentConsents = manager.currentPreferences?.asDictionary()
+
+        let expectedConsentsJSON = """
+        {
+          "consents": {
+            "adID": {
+              "val": "y"
+            },
+            "collect": {
+              "val": "n"
+            },
+            "metadata": {
+              "time": "STRING_TYPE"
+            }
+          }
+        }
+        """
+
+        // Verify stored consents
+        assertExactMatch(
+            expected: expectedConsentsJSON,
+            actual: storedConsents,
+            pathOptions:
+                ValueTypeMatch(paths: "consents.metadata.time"),
+            CollectionEqualCount(scope: .subtree))
+
+        // Verify current consents
+        assertExactMatch(
+            expected: expectedConsentsJSON,
+            actual: currentConsents,
+            pathOptions:
+                ValueTypeMatch(paths: "consents.metadata.time"),
+            CollectionEqualCount(scope: .subtree))
     }
 
     func testMergeAndUpdateMultipleMerges() {
@@ -145,19 +205,19 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
         let currentConsents = manager.currentPreferences?.asDictionary()
 
         let expectedConsentsJSON = #"""
-        {
-          "consents": {
+            {
+            "consents": {
             "adID": {
-              "val": "y"
+            "val": "y"
             },
             "collect": {
-              "val": "n"
+            "val": "n"
             },
             "metadata": {
-              "time": "STRING_TYPE"
+            "time": "STRING_TYPE"
             }
-          }
-        }
+            }
+            }
         """#
 
         // Verify stored consents
@@ -166,7 +226,7 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             actual: storedConsents,
             pathOptions:
                 ValueTypeMatch(paths: "consents.metadata.time"),
-                CollectionEqualCount(scope: .subtree))
+            CollectionEqualCount(scope: .subtree))
 
         // Verify current consents
         assertExactMatch(
@@ -174,7 +234,7 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             actual: currentConsents,
             pathOptions:
                 ValueTypeMatch(paths: "consents.metadata.time"),
-                CollectionEqualCount(scope: .subtree))
+            CollectionEqualCount(scope: .subtree))
 
         // Setup pt. 2 - Update `collect` `val` to "y"
         let date = Date()
@@ -193,19 +253,19 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
         let currentConsents_pt2 = manager.currentPreferences?.asDictionary()
 
         let expectedConsentsJSON_pt2 = #"""
-        {
-          "consents": {
+            {
+            "consents": {
             "adID": {
-              "val": "y"
+            "val": "y"
             },
             "collect": {
-              "val": "y"
+            "val": "y"
             },
             "metadata": {
-              "time": "STRING_TYPE"
+            "time": "STRING_TYPE"
             }
-          }
-        }
+            }
+            }
         """#
 
         // Verify stored consents
@@ -214,7 +274,7 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             actual: storedConsents_pt2,
             pathOptions:
                 ValueTypeMatch(paths: "consents.metadata.time"),
-                CollectionEqualCount(scope: .subtree))
+            CollectionEqualCount(scope: .subtree))
 
         // Verify current consents
         assertExactMatch(
@@ -222,7 +282,7 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             actual: currentConsents_pt2,
             pathOptions:
                 ValueTypeMatch(paths: "consents.metadata.time"),
-                CollectionEqualCount(scope: .subtree))
+            CollectionEqualCount(scope: .subtree))
     }
 
     // MARK: updateDefaults(...) tests
@@ -245,19 +305,19 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
         let defaultConsents = manager.defaultPreferences?.asDictionary()
 
         let expectedConsentsJSON = #"""
-        {
-          "consents": {
+            {
+            "consents": {
             "adID": {
-              "val": "y"
+            "val": "y"
             },
             "collect": {
-              "val": "n"
+            "val": "n"
             },
             "metadata": {
-              "time": "STRING_TYPE"
+            "time": "STRING_TYPE"
             }
-          }
-        }
+            }
+            }
         """#
 
         // Verify default consents
@@ -266,7 +326,7 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             actual: defaultConsents,
             pathOptions:
                 ValueTypeMatch(paths: "consents.metadata.time"),
-                CollectionEqualCount(scope: .subtree))
+            CollectionEqualCount(scope: .subtree))
     }
 
     func testUpdateDefaultsMultipleMerges() {
@@ -287,19 +347,19 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
         let defaultConsents = manager.defaultPreferences?.asDictionary()
 
         let expectedConsentsJSON = #"""
-        {
-          "consents": {
+            {
+            "consents": {
             "adID": {
-              "val": "y"
+            "val": "y"
             },
             "collect": {
-              "val": "n"
+            "val": "n"
             },
             "metadata": {
-              "time": "STRING_TYPE"
+            "time": "STRING_TYPE"
             }
-          }
-        }
+            }
+            }
         """#
 
         // Verify default consents
@@ -308,7 +368,7 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             actual: defaultConsents,
             pathOptions:
                 ValueTypeMatch(paths: "consents.metadata.time"),
-                CollectionEqualCount(scope: .subtree))
+            CollectionEqualCount(scope: .subtree))
 
         // Setup pt. 2 - Update removes `adID` `val`
         let date = Date()
@@ -326,16 +386,16 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
         let defaultConsents_pt2 = manager.defaultPreferences?.asDictionary()
 
         let expectedConsentsJSON_pt2 = #"""
-        {
-          "consents": {
+            {
+            "consents": {
             "collect": {
-              "val": "y"
+            "val": "y"
             },
             "metadata": {
-              "time": "STRING_TYPE"
+            "time": "STRING_TYPE"
             }
-          }
-        }
+            }
+            }
         """#
 
         // Verify default consents
@@ -344,8 +404,8 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             actual: defaultConsents_pt2,
             pathOptions:
                 ValueTypeMatch(paths: "consents.metadata.time"),
-                CollectionEqualCount(scope: .subtree),
-                KeyMustBeAbsent(paths: "consents.adID.val"))
+            CollectionEqualCount(scope: .subtree),
+            KeyMustBeAbsent(paths: "consents.adID.val"))
     }
 
     func testUpdateDefaultsWithExistingConsents_ShouldUpdate() {
@@ -375,22 +435,22 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
         let currentConsents = manager.currentPreferences?.asDictionary()
 
         let expectedConsentsJSON = #"""
-        {
-          "consents": {
+            {
+            "consents": {
             "adID": {
-              "val": "y"
+            "val": "y"
             },
             "collect": {
-              "val": "n"
+            "val": "n"
             },
             "metadata": {
-              "time": "STRING_TYPE"
+            "time": "STRING_TYPE"
             },
             "share": {
-              "val": "n"
+            "val": "n"
             }
-          }
-        }
+            }
+            }
         """#
 
         // Verify current consents
@@ -399,7 +459,7 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             actual: currentConsents,
             pathOptions:
                 ValueTypeMatch(paths: "consents.metadata.time"),
-                CollectionEqualCount(scope: .subtree))
+            CollectionEqualCount(scope: .subtree))
     }
 
     func testUpdateDefaultsWithExistingConsents_ShouldNotUpdate() {
@@ -429,19 +489,19 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
         let currentConsents = manager.currentPreferences?.asDictionary()
 
         let expectedConsentsJSON = #"""
-        {
-          "consents": {
+            {
+            "consents": {
             "adID": {
-              "val": "y"
+            "val": "y"
             },
             "collect": {
-              "val": "n"
+            "val": "n"
             },
             "metadata": {
-              "time": "STRING_TYPE"
+            "time": "STRING_TYPE"
             }
-          }
-        }
+            }
+            }
         """#
 
         // Verify current consents
@@ -450,7 +510,7 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             actual: currentConsents,
             pathOptions:
                 ValueTypeMatch(paths: "consents.metadata.time"),
-                CollectionEqualCount(scope: .subtree))
+            CollectionEqualCount(scope: .subtree))
     }
 
     func testUpdateDefaults_RemovalOfDefaultConsent() {
@@ -483,13 +543,13 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
         var currentConsents = manager.currentPreferences?.asDictionary()
 
         let expectedConsentsJSON = #"""
-        {
-          "consents": {
+            {
+            "consents": {
             "collect": {
-              "val": "y"
+            "val": "y"
             }
-          }
-        }
+            }
+            }
         """#
 
         // Verify current consents
@@ -498,6 +558,6 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             actual: currentConsents,
             pathOptions:
                 KeyMustBeAbsent(paths: "consents.adID.val"),
-                CollectionEqualCount(scope: .subtree))
+            CollectionEqualCount(scope: .subtree))
     }
 }

--- a/Tests/UnitTests/ConsentPreferencesManagerTests.swift
+++ b/Tests/UnitTests/ConsentPreferencesManagerTests.swift
@@ -74,6 +74,59 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             CollectionEqualCount(scope: .subtree))
     }
 
+    func testMergeAndUpdateNestedPreferences() {
+        // Setup
+        var manager = ConsentPreferencesManager()
+        let consents = [
+            "collect": ["val": "n"],
+            "marketing": ["preferred": "none", "push": ["val": "y"]],
+            "metadata": ["time": Date().iso8601UTCWithMillisecondsString]
+        ]
+        let preferences = ConsentPreferences(consents: AnyCodable.from(dictionary: consents)!)
+
+        // Test
+        XCTAssertTrue(manager.mergeAndUpdate(with: preferences))
+
+        // Verify
+        let storedConsents = manager.persistedPreferences?.asDictionary()
+        let currentConsents = manager.currentPreferences?.asDictionary()
+
+        let expectedConsentsJSON = """
+        {
+          "consents": {
+            "collect": {
+              "val": "n"
+            },
+            "marketing": {
+              "preferred": "none",
+              "push": {
+                "val": "y"
+              }
+            },
+            "metadata": {
+              "time": "STRING_TYPE"
+            }
+          }
+        }
+        """
+
+        // Verify stored consents
+        assertExactMatch(
+            expected: expectedConsentsJSON,
+            actual: storedConsents,
+            pathOptions:
+                ValueTypeMatch(paths: "consents.metadata.time"),
+            CollectionEqualCount(scope: .subtree))
+
+        // Verify current consents
+        assertExactMatch(
+            expected: expectedConsentsJSON,
+            actual: currentConsents,
+            pathOptions:
+                ValueTypeMatch(paths: "consents.metadata.time"),
+            CollectionEqualCount(scope: .subtree))
+    }
+
     func testMergeAndUpdateShouldReturnFalse() {
         // Setup
         var manager = ConsentPreferencesManager()
@@ -267,6 +320,111 @@ class ConsentPreferencesManagerTests: XCTestCase, AnyCodableAsserts {
             }
             }
         """#
+
+        // Verify stored consents
+        assertExactMatch(
+            expected: expectedConsentsJSON_pt2,
+            actual: storedConsents_pt2,
+            pathOptions:
+                ValueTypeMatch(paths: "consents.metadata.time"),
+            CollectionEqualCount(scope: .subtree))
+
+        // Verify current consents
+        assertExactMatch(
+            expected: expectedConsentsJSON_pt2,
+            actual: currentConsents_pt2,
+            pathOptions:
+                ValueTypeMatch(paths: "consents.metadata.time"),
+            CollectionEqualCount(scope: .subtree))
+    }
+
+    func testMergeAndUpdateMultipleMergesNestedPreferences() {
+        // Setup pt. 1
+        var manager = ConsentPreferencesManager()
+        let consents = [
+            "collect": ["val": "n"],
+            "marketing": ["preferred": "none", "push": ["val": "y"]],
+            "metadata": ["time": Date().iso8601UTCWithMillisecondsString]
+        ]
+        let preferences = ConsentPreferences(consents: AnyCodable.from(dictionary: consents)!)
+
+        // Test pt. 1
+        XCTAssertTrue(manager.mergeAndUpdate(with: preferences))
+
+        // Verify pt. 1
+        let storedConsents = manager.persistedPreferences?.asDictionary()
+        let currentConsents = manager.currentPreferences?.asDictionary()
+
+        let expectedConsentsJSON = """
+        {
+          "consents": {
+            "collect": {
+              "val": "n"
+            },
+            "marketing": {
+              "preferred": "none",
+              "push": {
+                "val": "y"
+              }
+            },
+            "metadata": {
+              "time": "STRING_TYPE"
+            }
+          }
+        }
+        """
+
+        // Verify stored consents
+        assertExactMatch(
+            expected: expectedConsentsJSON,
+            actual: storedConsents,
+            pathOptions:
+                ValueTypeMatch(paths: "consents.metadata.time"),
+            CollectionEqualCount(scope: .subtree))
+
+        // Verify current consents
+        assertExactMatch(
+            expected: expectedConsentsJSON,
+            actual: currentConsents,
+            pathOptions:
+                ValueTypeMatch(paths: "consents.metadata.time"),
+            CollectionEqualCount(scope: .subtree))
+
+        // Setup pt. 2 - Update `marketing` `preferred` to `sms` and add `sms` `val` to "y"
+        let consents_pt2 = [
+            "marketing": ["preferred": "sms", "sms": ["val": "y"]],
+            "metadata": ["time": Date().iso8601UTCWithMillisecondsString]
+        ]
+        let preferences_pt2 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents_pt2)!)
+
+        // Test pt. 2
+        XCTAssertTrue(manager.mergeAndUpdate(with: preferences_pt2))
+
+        // Verify pt. 2
+        let storedConsents_pt2 = manager.persistedPreferences?.asDictionary()
+        let currentConsents_pt2 = manager.currentPreferences?.asDictionary()
+
+        let expectedConsentsJSON_pt2 = """
+        {
+          "consents": {
+            "collect": {
+              "val": "n"
+            },
+            "marketing": {
+              "preferred": "sms",
+              "push": {
+                "val": "y"
+              },
+              "sms": {
+                "val": "y"
+              }
+            },
+            "metadata": {
+              "time": "STRING_TYPE"
+            }
+          }
+        }
+        """
 
         // Verify stored consents
         assertExactMatch(

--- a/Tests/UnitTests/ConsentPreferencesTests.swift
+++ b/Tests/UnitTests/ConsentPreferencesTests.swift
@@ -417,6 +417,79 @@ class ConsentPreferencesTests: XCTestCase, AnyCodableAsserts {
         XCTAssertTrue(equal)
     }
 
+    // MARK: equals operator tests
+
+    func testEqualsWithEqualConsentPreferences() {
+        // Setup
+        let consents = [
+            "adID": ["val": "y"],
+            "collect": ["val": "n"],
+            "metadata": ["time": Date().iso8601UTCWithMillisecondsString]
+        ]
+        let preferences1 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents)!)
+        let preferences2 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents)!)
+
+        // Test
+        XCTAssertTrue(preferences1 == preferences2)
+    }
+
+    func testEqualsWithDifferentConsentPreferences() {
+        // Setup
+        let consents1 = [
+            "adID": ["val": "y"],
+            "collect": ["val": "n"]
+        ]
+        let preferences1 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents1)!)
+        let consents2 = [
+            "adID": ["val": "y"],
+            "collect": ["val": "y"]
+        ]
+        let preferences2 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents2)!)
+
+        // Test
+        XCTAssertFalse(preferences1 == preferences2)
+    }
+
+    func testEqualsWithDifferentDictionaryOrder() {
+        // Setup
+        let timestamp = Date().iso8601UTCWithMillisecondsString
+        let consents1 = [
+            "adID": ["val": "y"],
+            "collect": ["val": "n"],
+            "metadata": ["time": timestamp]
+        ]
+        let consents2 = [
+            "collect": ["val": "n"],
+            "adID": ["val": "y"],
+            "metadata": ["time": timestamp]
+        ]
+        let preferences1 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents1)!)
+        let preferences2 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents2)!)
+
+        // Test
+        XCTAssertTrue(preferences1 == preferences2)
+    }
+
+    func testEqualsDifferentTimestamp() {
+        // Setup
+        let consents1 = [
+            "adID": ["val": "y"],
+            "collect": ["val": "n"],
+            "metadata": ["time": Date().iso8601UTCWithMillisecondsString]
+        ]
+        let consents2 = [
+            "adID": ["val": "y"],
+            "collect": ["val": "n"],
+            "metadata": ["time": Date().addingTimeInterval(10).iso8601UTCWithMillisecondsString]
+        ]
+        let preferences1 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents1)!)
+        let preferences2 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents2)!)
+
+        // Test
+        // Expect true because equality ignores timestamp
+        XCTAssertTrue(preferences1 == preferences2)
+    }
+
     // MARK: from(config) tests
 
     func testFromEmptyConfig() {

--- a/Tests/UnitTests/ConsentPreferencesTests.swift
+++ b/Tests/UnitTests/ConsentPreferencesTests.swift
@@ -417,34 +417,109 @@ class ConsentPreferencesTests: XCTestCase, AnyCodableAsserts {
         XCTAssertTrue(equal)
     }
 
-    // MARK: equals operator tests
-
-    func testEqualsWithEqualConsentPreferences() {
+    func testMergeWithNestedConsentsPreferences() {
         // Setup
         let consents = [
-            "adID": ["val": "y"],
-            "collect": ["val": "n"],
+            "collect": ["val": "y"],
+            "marketing": ["preferred": "none", "email": ["val": "y"]],
             "metadata": ["time": Date().iso8601UTCWithMillisecondsString]
         ]
-        let preferences1 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents)!)
-        let preferences2 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents)!)
+        let preferences = ConsentPreferences(consents: AnyCodable.from(dictionary: consents)!)
+
+        let date = Date()
+        let otherConsents = [
+            "marketing": ["preferred": "push", "push": ["val": "y"]],
+            "metadata": ["time": date.iso8601UTCWithMillisecondsString]
+        ]
+        let otherPreferences = ConsentPreferences(consents: AnyCodable.from(dictionary: otherConsents)!)
+
+        // Test
+        let mergedPreferences = preferences.merge(with: otherPreferences)
+
+        // Verify
+        let expectedConsents = [
+            "collect": ["val": "y"],
+            "marketing": ["preferred": "push", "push": ["val": "y"], "email": ["val": "y"]],
+            "metadata": ["time": date.iso8601UTCWithMillisecondsString]
+        ]
+        let expectedPreferences = ConsentPreferences(consents: AnyCodable.from(dictionary: expectedConsents)!)
+
+        let equal = NSDictionary(dictionary: AnyCodable.toAnyDictionary(dictionary: mergedPreferences.consents)!).isEqual(to: AnyCodable.toAnyDictionary(dictionary: expectedPreferences.consents)!)
+        XCTAssertTrue(equal)
+    }
+
+    // MARK: equals operator tests
+
+    func testEqualsWithEqualConsentPreferencesSimple() {
+        // Setup
+        let consents = [
+            "consents": [
+                "adID": ["val": "y"],
+                "collect": ["val": "n"],
+                "metadata": ["time": Date().iso8601UTCWithMillisecondsString]
+            ]
+        ]
+        let preferences1 = ConsentPreferences.from(eventData: consents)
+        let preferences2 = ConsentPreferences.from(eventData: consents)
 
         // Test
         XCTAssertTrue(preferences1 == preferences2)
     }
 
-    func testEqualsWithDifferentConsentPreferences() {
+    func testEqualsWithEqualConsentPreferencesNested() {
+        // Setup
+        let consents = [
+            "consents": [
+                "collect": ["val": "n"],
+                "marketing": ["preferred": "push", "push": ["val": "y"], "email": ["val": "y"]],
+                "metadata": ["time": Date().iso8601UTCWithMillisecondsString]
+            ]
+        ]
+        let preferences1 = ConsentPreferences.from(eventData: consents)
+        let preferences2 = ConsentPreferences.from(eventData: consents)
+        // Test
+        XCTAssertTrue(preferences1 == preferences2)
+    }
+
+    func testEqualsWithDifferentConsentPreferencesSimple() {
         // Setup
         let consents1 = [
-            "adID": ["val": "y"],
-            "collect": ["val": "n"]
+            "consents": [
+                "adID": ["val": "y"],
+                "collect": ["val": "n"]
+            ]
         ]
-        let preferences1 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents1)!)
+        let preferences1 = ConsentPreferences.from(eventData: consents1)
         let consents2 = [
-            "adID": ["val": "y"],
-            "collect": ["val": "y"]
+            "consents": [
+                "adID": ["val": "y"],
+                "collect": ["val": "y"]
+            ]
         ]
-        let preferences2 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents2)!)
+        let preferences2 = ConsentPreferences.from(eventData: consents2)
+
+        // Test
+        XCTAssertFalse(preferences1 == preferences2)
+    }
+
+    func testEqualsWithDifferentConsentPreferencesNested() {
+        // Setup
+        let consents1 = [
+            "consents": [
+                "adID": ["val": "y"],
+                "collect": ["val": "y"],
+                "marketing": ["preferred": "push", "push": ["val": "y"], "email": ["val": "y"]] // email is 'y'
+            ]
+        ]
+        let preferences1 = ConsentPreferences.from(eventData: consents1)
+        let consents2 = [
+            "consents": [
+                "adID": ["val": "y"],
+                "collect": ["val": "y"],
+                "marketing": ["preferred": "push", "push": ["val": "y"], "email": ["val": "n"]]  // email is 'n'
+            ]
+        ]
+        let preferences2 = ConsentPreferences.from(eventData: consents2)
 
         // Test
         XCTAssertFalse(preferences1 == preferences2)
@@ -454,17 +529,21 @@ class ConsentPreferencesTests: XCTestCase, AnyCodableAsserts {
         // Setup
         let timestamp = Date().iso8601UTCWithMillisecondsString
         let consents1 = [
-            "adID": ["val": "y"],
-            "collect": ["val": "n"],
-            "metadata": ["time": timestamp]
+            "consents": [
+                "adID": ["val": "y"],
+                "collect": ["val": "n"],
+                "metadata": ["time": timestamp]
+            ]
         ]
         let consents2 = [
-            "collect": ["val": "n"],
-            "adID": ["val": "y"],
-            "metadata": ["time": timestamp]
+            "consents": [
+                "collect": ["val": "n"],
+                "adID": ["val": "y"],
+                "metadata": ["time": timestamp]
+            ]
         ]
-        let preferences1 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents1)!)
-        let preferences2 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents2)!)
+        let preferences1 = ConsentPreferences.from(eventData: consents1)
+        let preferences2 = ConsentPreferences.from(eventData: consents2)
 
         // Test
         XCTAssertTrue(preferences1 == preferences2)
@@ -473,18 +552,21 @@ class ConsentPreferencesTests: XCTestCase, AnyCodableAsserts {
     func testEqualsDifferentTimestamp() {
         // Setup
         let consents1 = [
-            "adID": ["val": "y"],
-            "collect": ["val": "n"],
-            "metadata": ["time": Date().iso8601UTCWithMillisecondsString]
+            "consents": [
+                "adID": ["val": "y"],
+                "collect": ["val": "n"],
+                "metadata": ["time": Date().iso8601UTCWithMillisecondsString]
+            ]
         ]
         let consents2 = [
-            "adID": ["val": "y"],
-            "collect": ["val": "n"],
-            "metadata": ["time": Date().addingTimeInterval(10).iso8601UTCWithMillisecondsString]
+            "consents": [
+                "adID": ["val": "y"],
+                "collect": ["val": "n"],
+                "metadata": ["time": Date().addingTimeInterval(10).iso8601UTCWithMillisecondsString]
+            ]
         ]
-        let preferences1 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents1)!)
-        let preferences2 = ConsentPreferences(consents: AnyCodable.from(dictionary: consents2)!)
-
+        let preferences1 = ConsentPreferences.from(eventData: consents1)
+        let preferences2 = ConsentPreferences.from(eventData: consents2)
         // Test
         // Expect true because equality ignores timestamp
         XCTAssertTrue(preferences1 == preferences2)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Merge to Staging for v5.0.1 release:

- Optimize Consent by suppressing repeated Consent.update calls received within on second if the consent preferences do not change.
- Fix issue where consent preferences were not merged correctly on the device when using deeply nested consents structure.
- Update scripts to use gha-ios-5.3.3
- Fix build scripts to correctly set BUILD_LIBRARY_FOR_DISTRIBUTION as it was misspelled previously.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
